### PR TITLE
상점 데이터 동기화, 탭 전환 기능 구현

### DIFF
--- a/AbyssDiverUnderWorld.uproject
+++ b/AbyssDiverUnderWorld.uproject
@@ -11,7 +11,8 @@
 			"AdditionalDependencies": [
 				"Engine",
 				"AIModule",
-				"UMG"
+				"UMG",
+				"CoreUObject"
 			]
 		}
 	],

--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ElementInfoPanel.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ElementInfoPanel.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9daa578cea1080215194f72627d0b692eaf15da90ee4593cf041d9349eb836d6
-size 33146
+oid sha256:7675f8edeba9af0160b295414d337010c4c8edf5f0ea8574989cbb7affcccb53
+size 33080

--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_Shop.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_Shop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:302838c44cef400bc67327b2f51d2d0ff656ab6aa33c37603beb6ef8509b79b3
-size 19733
+oid sha256:91fcc6c5288a36194ac2b520951ef7186d8a1492034d247c7e5026a8a97efbd9
+size 38873

--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ShopCategoryTap.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ShopCategoryTap.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27f7ac5aaedca39fe0afdedbf20f63cfb9e161fbfc43996387685c76f2ac703f
-size 24961
+oid sha256:b39cb79c7a12b286f6c4e98a65bfe0fe0f062b07ff1c7091eadca97db514c925
+size 25605

--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ShopItemSlot.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ShopItemSlot.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8abacb4ed226eade32888a916e5081f6a98541a7f8ccd5d1c41a03458c162eb
-size 19885
+oid sha256:2bd86881efe85c6596b8c2d17ec0f2e0029f88a49d302360d7d70d6a590b7ec1
+size 31361

--- a/Content/_AbyssDiver/M_SciFi_Octopuse_Body_Skin1.uasset
+++ b/Content/_AbyssDiver/M_SciFi_Octopuse_Body_Skin1.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94981cd7efd3539b68ee30ee5907dc75061df4bcf9e2034097f74328d86f063b
-size 26594

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestShop.uasset
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestShop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:533362ee514fec0114d949ec022eb47590a08e6327a23db8349635005dc9b989
-size 29246
+oid sha256:fdbd533fd4236bd2d80e573cce0e53731fde176795dd9dc235a9a94ee70148d4
+size 30554

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/DT_Test.uasset
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/DT_Test.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1946e7456cabc74d5ce863e4154aadeba3b158a52663819e27aedbf59183a44e
+size 6943

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:576fb7e187bdfd2fe7eddbf7a406ae56bc1220eec05a2c93b53d07674cde084a
+oid sha256:57326b4dbc2ffdc5c187ca3031075a2de70fe87a0abea7f56be3bfba824fdd78
 size 54958

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
@@ -2,17 +2,144 @@
 
 #include "Character/UnitBase.h"
 #include "Shops/ShopWidgets/ShopCategoryTabWidget.h"
+#include "Shops/ShopWidgets/ShopWidget.h"
+#include "Shops/ShopItemEntryData.h"
+#include "DataRow/FADItemDataRow.h"
 #include "AbyssDiverUnderWorld.h"
+
+#include "DataRow/FADItemDataRow.h"
+#include "Net/UnrealNetwork.h"
+#include "Kismet/GameplayStatics.h"
+
+#pragma region FShopItemId
+
+void FShopItemId::PostReplicatedAdd(const FShopItemIdList& InArraySerializer)
+{
+	UE_LOG(LogTemp, Log, TEXT("Shop item added: Id = %d"), Id);
+
+	int32 Index = InArraySerializer.IdList.IndexOfByKey(*this);
+	FShopItemListChangeInfo Info(InArraySerializer.TabType, Index, Id, EShopItemChangeType::Added);
+
+	InArraySerializer.OnShopItemListChangedDelegate.Broadcast(Info);
+}
+
+void FShopItemId::PostReplicatedChange(const FShopItemIdList& InArraySerializer)
+{
+	UE_LOG(LogTemp, Log, TEXT("Shop item changed: Id = %d"), Id);
+
+	int32 Index = InArraySerializer.IdList.IndexOfByKey(*this);
+	FShopItemListChangeInfo Info(InArraySerializer.TabType, Index, Id, EShopItemChangeType::Modified);
+
+	InArraySerializer.OnShopItemListChangedDelegate.Broadcast(Info);
+}
+
+void FShopItemId::PreReplicatedRemove(const FShopItemIdList& InArraySerializer)
+{
+	UE_LOG(LogTemp, Log, TEXT("Shop item removed: Id = %d"), Id);
+
+	int32 Index = InArraySerializer.IdList.IndexOfByKey(*this);
+	FShopItemListChangeInfo Info(InArraySerializer.TabType, Index, Id, EShopItemChangeType::Removed);
+
+	InArraySerializer.OnShopItemListChangedDelegate.Broadcast(Info);
+}
+
+#pragma endregion
+
+#pragma region FShopItemIdList
+
+bool FShopItemIdList::NetDeltaSerialize(FNetDeltaSerializeInfo& DeltaParams)
+{
+	return FFastArraySerializer::FastArrayDeltaSerialize<FShopItemId, FShopItemIdList>(IdList, DeltaParams, *this);
+}
+
+int32 FShopItemIdList::Contains(uint8 CompareId)
+{
+	int32 ElementCount = IdList.Num();
+	for (int32 i = 0; i < ElementCount; ++i)
+	{
+		if (IdList[i].Id == CompareId)
+		{
+			return i;
+		}
+	}
+
+	return INDEX_NONE;
+}
+
+bool FShopItemIdList::TryAdd(uint8 NewId)
+{
+	if (Contains(NewId) != INDEX_NONE)
+	{
+		UE_LOG(LogTemp, Log, TEXT("You Trying to Add Exist Id : %d"), NewId);
+		return false;
+	}
+	FShopItemId ShopId;
+	ShopId.Id = NewId;
+
+	IdList.Add(ShopId);
+	MarkItemDirty(IdList.Last());
+
+	return true;
+}
+
+void FShopItemIdList::Remove(uint8 Id)
+{
+	int32 Index = Contains(Id);
+	if (Index == INDEX_NONE)
+	{
+		UE_LOG(LogTemp, Log, TEXT("You Trying to Remove Not Exist Id : %d"), Id);
+		return;
+	}
+
+	IdList.RemoveAt(Index);
+	MarkArrayDirty();
+}
+
+void FShopItemIdList::Modify(uint8 InIndex, uint8 NewId)
+{
+	if (IdList.IsValidIndex(InIndex) == false)
+	{
+		UE_LOG(LogTemp, Log, TEXT("You Trying to Modify From Not Valid Index : %d"), InIndex);
+		return;
+	}
+
+	FShopItemId& ItemId = IdList[InIndex];
+	ItemId.Id = NewId;
+	MarkItemDirty(ItemId);
+}
+
+uint8 FShopItemIdList::GetId(uint8 InIndex) const
+{
+	if (IdList.IsValidIndex(InIndex) == false)
+	{
+		UE_LOG(LogTemp, Log, TEXT("You Trying to Get From Not Valid Index"));
+		return INDEX_NONE;
+	}
+
+	return IdList[InIndex].Id;
+}
+#pragma endregion
 
 AShop::AShop()
 {
 	PrimaryActorTick.bCanEverTick = false;
+	bReplicates = true;
+}
 
+void AShop::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	DOREPLIFETIME(AShop, ShopConsumableItemIdList);
+	DOREPLIFETIME(AShop, ShopEquipmentItemIdList);
 }
 
 void AShop::BeginPlay()
 {
 	Super::BeginPlay();
+
+	InitShopWidget();
+	InitData();
 }
 
 void AShop::Tick(float DeltaTime)
@@ -20,8 +147,14 @@ void AShop::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 }
 
-EBuyResult AShop::BuyItem(int32 ItemId)
+EBuyResult AShop::BuyItem(uint8 ItemId, EShopCategoryTab TabType)
 {
+	if (HasAuthority() == false)
+	{
+		LOGVN(Log, TEXT("Has No Authority"));
+		return EBuyResult::HasNoAuthority;
+	}
+
 	/*if (돈이 없으면)
 	{
 		return EBuyResult::NotEnoughMoney;
@@ -37,8 +170,14 @@ EBuyResult AShop::BuyItem(int32 ItemId)
 	return EBuyResult::Succeeded;
 }
 
-ESellResult AShop::SellItem(int32 ItemId, class AUnitBase* Seller)
+ESellResult AShop::SellItem(uint8 ItemId, class AUnitBase* Seller)
 {
+	if (HasAuthority() == false)
+	{
+		LOGVN(Log, TEXT("Has No Authority"));
+		return ESellResult::HasNoAuthority;
+	}
+
 	/*if (아이템 안 갖고 있으면)
 	{
 		return ESellResult::NotExistItem;
@@ -50,29 +189,141 @@ ESellResult AShop::SellItem(int32 ItemId, class AUnitBase* Seller)
 	return ESellResult::Succeeded;
 }
 
-void AShop::InitData()
+void AShop::AddItems(const TArray<uint8>& Ids, EShopCategoryTab TabType)
 {
-	// 아이템 데이터 테이블로부터 아이템 Id 리스트를 통해 데이터 가져와야 함.
-}
-
-void AShop::OnCategoryTabClicked(ECategoryTab CategoryTab)
-{
-	if (CategoryTab == ECategoryTab::None)
+	if (HasAuthority() == false)
 	{
-		LOGV(Error, TEXT("ShopCategoryTab is not Defined Category"));
+		LOGVN(Log, TEXT("Has No Authority"));
 		return;
 	}
 
+	for (auto& Id : Ids)
+	{
+		AddItemToList(Id, TabType);
+	}
+}
 
+void AShop::AddItemToList(uint8 ItemId, EShopCategoryTab TabType)
+{
+	if (HasAuthority() == false)
+	{
+		LOGVN(Log, TEXT("Has No Authority"));
+		return;
+	}
+
+	ShopConsumableItemIdList.TryAdd(ItemId);
+}
+
+void AShop::RemoveItemToList(uint8 ItemId, EShopCategoryTab TabType)
+{
+	if (HasAuthority() == false)
+	{
+		LOGVN(Log, TEXT("Has No Authority"));
+		return;
+	}
+
+	ShopConsumableItemIdList.Remove(ItemId);
+}
+
+void AShop::InitShopWidget()
+{
+	ShopConsumableItemIdList.IdList.Empty();
+	ShopConsumableItemIdList.OnShopItemListChangedDelegate.AddUObject(this, &AShop::OnShopItemListChanged);
+	ShopConsumableItemIdList.ShopOwner = this;
+	ShopConsumableItemIdList.TabType = EShopCategoryTab::Consumable;
+
+	ShopEquipmentItemIdList.IdList.Empty();
+	ShopEquipmentItemIdList.OnShopItemListChangedDelegate.AddUObject(this, &AShop::OnShopItemListChanged);
+	ShopEquipmentItemIdList.ShopOwner = this;
+	ShopConsumableItemIdList.TabType = EShopCategoryTab::Consumable;
+
+	ShopWidget = CreateWidget<UShopWidget>(GetWorld(), ShopWidgetClass, FName(TEXT("ShopWidget")));
+	check(ShopWidget);
+
+	ShopWidget->SetCurrentActivatedTab(EShopCategoryTab::Consumable);
+	ShopWidget->AddToViewport();
+}
+
+void AShop::InitData()
+{
+	// 아이템 데이터 테이블로부터 아이템 Id 리스트를 통해 데이터 가져와야 함.
+	// 현재 임시 테이블 사용
+	ItemDataTable->GetAllRows<FFADItemDataRow>(TEXT("TestShopItemData"), DataTableArray);
+
+	Algo::Sort(DataTableArray, [](const FFADItemDataRow* A, const FFADItemDataRow* B)
+		{
+			return A->Id < B->Id;
+		});
+
+	if (HasAuthority() == false)
+	{
+		return;
+	}
+
+	ShopConsumableItemIdList.MarkArrayDirty();
+
+	for (const auto& Id : DefaultConsumableItemIdList)
+	{
+		FFADItemDataRow*& Data = DataTableArray[Id];
+
+		UShopItemEntryData* EntryData = NewObject<UShopItemEntryData>();
+		EntryData->Init(Data->Price, Data->Thumbnail, Data->Description); // 임시
+
+		if (Data->ItemType == EItemType::Consumable)
+		{
+			ShopWidget->AddItem(EntryData, EShopCategoryTab::Consumable);
+		}
+
+		ShopConsumableItemIdList.TryAdd(Id);
+	}
+
+	ShopWidget->ShowItemViewForTab(EShopCategoryTab::Consumable);
+
+	ShopEquipmentItemIdList.MarkArrayDirty();
+
+	for (const auto& Id : DefaultEquipmentItemIdList)
+	{
+		FFADItemDataRow*& Data = DataTableArray[Id];
+
+		UShopItemEntryData* EntryData = NewObject<UShopItemEntryData>();
+		EntryData->Init(Data->Price, Data->Thumbnail, Data->Description); // 임시
+
+		if (Data->ItemType == EItemType::Equipment)
+		{
+			ShopWidget->AddItem(EntryData, EShopCategoryTab::Equipment);
+		}
+
+		ShopEquipmentItemIdList.TryAdd(Id);
+	}
+}
+
+void AShop::OnShopItemListChanged(const FShopItemListChangeInfo& Info)
+{
+	LOGVN(Error, TEXT("Changed!"));
+	
+	FFADItemDataRow*& Data = DataTableArray[Info.ItemIdAfter];
+
+	UShopItemEntryData* EntryData = NewObject<UShopItemEntryData>();
+	EntryData->Init(Data->Price, Data->Thumbnail, Data->Description); // 임시
+
+	if (Data->ItemType == EItemType::Consumable)
+	{
+		ShopWidget->AddItem(EntryData, EShopCategoryTab::Consumable);
+	}
+	else if (Data->ItemType == EItemType::Equipment)
+	{
+		ShopWidget->AddItem(EntryData, EShopCategoryTab::Equipment);
+	}
+
+	ShopWidget->RefreshItemView();
 }
 
 bool AShop::HasItem(int32 ItemId)
 {
-	return ShopItemIdList.Contains(ItemId);
+	return (ShopConsumableItemIdList.Contains(ItemId) != INDEX_NONE);
 }
 
 bool AShop::IsItemMeshCached(int32 ItemId)
 {
 	return CachedMeshList.Contains(ItemId);
 }
-

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.h
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.h
@@ -3,7 +3,11 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 
+#include "Net/Serialization/FastArraySerializer.h"
+
 #include "Shop.generated.h"
+
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnShopItemListChangedDelegate, const FShopItemListChangeInfo&);
 
 USTRUCT()
 struct FShopItemData
@@ -13,7 +17,7 @@ struct FShopItemData
 	UPROPERTY();
 	TObjectPtr<UTexture2D> ItemImageTexture;
 
-	int32 ItemId;
+	uint8 ItemId;
 	
 	int32 ItemPrice;
 
@@ -21,29 +25,136 @@ struct FShopItemData
 
 	FString Description;
 };
-
-enum class EShopTapType
-{
-	Consumable,
-	Weapons,
-	Upgrade
-};
+#pragma region Enums
 
 enum class EBuyResult
 {
 	Succeeded,
 	NotEnoughMoney,
 	NotExistItem,
+	HasNoAuthority,
+	FailedFromOtherReason,
+	Max
 };
 
 enum class ESellResult
 {
 	Succeeded,
-	NotExistItem
+	NotExistItem,
+	HasNoAuthority,
+	FailedFromOtherReason,
+	Max
 };
 
-enum class ECategoryTab : uint8;
+enum class EShopItemChangeType
+{
+	Added,
+	Removed,
+	Modified,
+	Max
+};
+
+#pragma endregion
+
+class AShop;
 class UShopWidget;
+class UShopItemEntryData;
+
+struct FFADItemDataRow;
+struct FShopItemIdList;
+
+enum class EShopCategoryTab : uint8;
+
+#pragma region FastArraySerializer
+
+USTRUCT()
+struct FShopItemListChangeInfo
+{
+	GENERATED_BODY()
+
+	FShopItemListChangeInfo()
+	{
+	}
+
+	FShopItemListChangeInfo(EShopCategoryTab InTab, int16 InShopIndex, uint8 InItemId, EShopItemChangeType InChangeType)
+	{
+		WhichTab = InTab;
+		ShopIndex = InShopIndex;
+		ItemIdAfter = InItemId;
+		ChangeType = InChangeType;
+	}
+
+	EShopCategoryTab WhichTab;
+	int16 ShopIndex;
+	uint8 ItemIdAfter;
+	EShopItemChangeType ChangeType;
+};
+
+USTRUCT(BlueprintType)
+struct FShopItemId : public FFastArraySerializerItem
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	uint8 Id;
+
+	void PostReplicatedAdd(const FShopItemIdList& InArraySerializer);
+
+	void PostReplicatedChange(const FShopItemIdList& InArraySerializer);
+
+	void PreReplicatedRemove(const FShopItemIdList& InArraySerializer);
+
+	bool operator==(const FShopItemId& Other) const
+	{
+		return Id == Other.Id;
+	}
+};
+
+USTRUCT(BlueprintType)
+struct FShopItemIdList : public FFastArraySerializer
+{
+	GENERATED_BODY()
+
+public:
+
+	bool NetDeltaSerialize(FNetDeltaSerializeInfo& DeltaParams);
+
+	// 인덱스 반환, 없으면 INDEX_NONE 반환
+	int32 Contains(uint8 CompareId);
+
+	bool TryAdd(uint8 NewId);
+
+	void Remove(uint8 Id);
+
+	void Modify(uint8 InIndex, uint8 NewId);
+
+	FOnShopItemListChangedDelegate OnShopItemListChangedDelegate;
+public:
+
+	UPROPERTY()
+	TArray<FShopItemId> IdList;
+
+	UPROPERTY()
+	TObjectPtr<AShop> ShopOwner;
+
+	EShopCategoryTab TabType;
+
+public:
+
+	// 유효하지 않으면 INDEX_NONE 반환
+	uint8 GetId(uint8 InIndex) const;
+};
+
+template<>
+struct TStructOpsTypeTraits<FShopItemIdList> : public TStructOpsTypeTraitsBase2<FShopItemIdList>
+{
+	enum
+	{
+		WithNetDeltaSerializer = true,
+	};
+};
+
+#pragma endregion
 
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API AShop : public AActor
@@ -56,6 +167,7 @@ public:
 
 protected:
 
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 	virtual void BeginPlay() override;
 	virtual void Tick(float DeltaTime) override;
 
@@ -63,17 +175,22 @@ protected:
 
 public:
 
-	EBuyResult BuyItem(int32 ItemId);
-	ESellResult SellItem(int32 ItemId, class AUnitBase* Seller);
+	EBuyResult BuyItem(uint8 ItemId, EShopCategoryTab TabType);
+	ESellResult SellItem(uint8 ItemId, class AUnitBase* Seller);
+
+	void AddItems(const TArray<uint8>& Ids, EShopCategoryTab TabType);
+	void AddItemToList(uint8 ItemId, EShopCategoryTab TabType);
+	void RemoveItemToList(uint8 ItemId, EShopCategoryTab TabType);
 
 protected:
 
+	void InitShopWidget();
 	void InitData();
 
 private:
 
 	UFUNCTION()
-	void OnCategoryTabClicked(ECategoryTab CategoryTab);
+	void OnShopItemListChanged(const FShopItemListChangeInfo& Info);
 
 	bool HasItem(int32 ItemId);
 	bool IsItemMeshCached(int32 ItemId);
@@ -85,8 +202,23 @@ private:
 
 protected:
 
-	UPROPERTY(EditAnywhere, Category = "Shop")
-	TArray<int32> ShopItemIdList;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TObjectPtr<UDataTable> ItemDataTable; // 테스트용
+
+	UPROPERTY(EditDefaultsOnly, Category = "Shop");
+	TArray<uint8> DefaultConsumableItemIdList; // 블루프린트 노출용
+
+	UPROPERTY(EditDefaultsOnly, Category = "Shop");
+	TArray<uint8> DefaultEquipmentItemIdList; // 블루프린트 노출용
+
+	UPROPERTY(Replicated)
+	FShopItemIdList ShopConsumableItemIdList;
+
+	UPROPERTY(Replicated)
+	FShopItemIdList ShopEquipmentItemIdList;
+
+	UPROPERTY(EditDefaultsOnly, Category = "Shop")
+	TSubclassOf<UShopWidget> ShopWidgetClass;
 
 	UPROPERTY()
 	TObjectPtr<UShopWidget> ShopWidget;
@@ -99,7 +231,7 @@ private:
 	UPROPERTY()
 	TMap<int32, TObjectPtr<UObject>> CachedMeshList;
 
+	TArray<FFADItemDataRow*> DataTableArray;
+
 #pragma endregion
-
-
 };

--- a/Source/AbyssDiverUnderWorld/Shops/ShopItemEntryData.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopItemEntryData.cpp
@@ -1,0 +1,23 @@
+#include "Shops/ShopItemEntryData.h"
+
+void UShopItemEntryData::Init(int32 NewPrice, UTexture2D* NewItemImage, const FString& NewToolTipText)
+{
+	Price = NewPrice;
+	ItemImage = NewItemImage;
+	ToolTipText = NewToolTipText;
+}
+
+int32 UShopItemEntryData::GetPrice() const
+{
+	return Price;
+}
+
+UTexture2D* UShopItemEntryData::GetItemImage() const
+{
+	return ItemImage;
+}
+
+const FString& UShopItemEntryData::GetToolTipText() const
+{
+	return ToolTipText;
+}

--- a/Source/AbyssDiverUnderWorld/Shops/ShopItemEntryData.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopItemEntryData.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+
+#include "ShopItemEntryData.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ABYSSDIVERUNDERWORLD_API UShopItemEntryData : public UObject
+{
+	GENERATED_BODY()
+
+#pragma region Methods
+
+
+
+public:
+
+	void Init(int32 NewPrice, UTexture2D* NewItemImage, const FString& NewToolTipText);
+
+#pragma endregion
+
+#pragma region Variables
+
+private:
+
+	UPROPERTY()
+	TObjectPtr<UTexture2D> ItemImage;
+
+	int32 Price = 0;
+	FString ToolTipText;
+
+#pragma endregion
+
+#pragma region Getters, Setters
+
+public:
+
+	int32 GetPrice() const;
+	UTexture2D* GetItemImage() const;
+	const FString& GetToolTipText() const;
+#pragma endregion
+
+};

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopCategoryTabWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopCategoryTabWidget.cpp
@@ -1,5 +1,7 @@
 #include "ShopCategoryTabWidget.h"
 
+#include "AbyssDiverUnderWorld.h"
+
 #include "Components/Button.h"
 
 void UShopCategoryTabWidget::NativeConstruct()

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopCategoryTabWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopCategoryTabWidget.h
@@ -5,16 +5,15 @@
 
 #include "ShopCategoryTabWidget.generated.h"
 
-DECLARE_MULTICAST_DELEGATE_OneParam(FOnShopCategoryTabClickedDelegate, ECategoryTab);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnShopCategoryTabClickedDelegate, EShopCategoryTab);
 
 UENUM()
-enum class ECategoryTab : uint8
+enum class EShopCategoryTab : uint8
 {
-	None,
-	Consumable,
-	Weapons,
+	Consumable = 0,
+	Equipment,
 	Upgrade,
-	MAX
+	Max
 };
 
 /**
@@ -29,7 +28,7 @@ protected:
 
 	virtual void NativeConstruct() override;
 
-#pragma region Methods And Delegate
+#pragma region Methods And Delegates
 public:
 
 	FOnShopCategoryTabClickedDelegate OnShopCategoryTabClickedDelegate;
@@ -46,11 +45,11 @@ private:
 
 private:
 
+	UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess), Category = "ShopCategoryTabWidget")
+	EShopCategoryTab CurrentCategoryTab = EShopCategoryTab::Max;
+
 	UPROPERTY(EditDefaultsOnly, meta = (BindWidget), Category = "ShopCategoryTabWidget")
 	TObjectPtr<class UButton> TabButton;
-
-	UPROPERTY(EditDefaultsOnly, meta = (AllowPrivateAccess), Category = "ShopCategoryTabWidget")
-	ECategoryTab CurrentCategoryTab = ECategoryTab::None;
 
 #pragma endregion
 };

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.cpp
@@ -1,10 +1,29 @@
 #include "ShopItemSlotWidget.h"
 
+#include "AbyssDiverUnderWorld.h"
+#include "Shops/ShopItemEntryData.h"
+
+#include "Components/Image.h"
+#include "Components/RichTextBlock.h"
+
+void UShopItemSlotWidget::NativeOnListItemObjectSet(UObject* ListItemObject)
+{
+    IUserObjectListEntry::NativeOnListItemObjectSet(ListItemObject);
+
+    UShopItemEntryData* EntryData = Cast<UShopItemEntryData>(ListItemObject);
+    if (EntryData == nullptr)
+    {
+        LOG(TEXT("EntryData == nullptr"));
+        return;
+    }
+
+    SetSlotImage(EntryData->GetItemImage());
+    SetToolTipText(EntryData->GetToolTipText());
+}
+
 FReply UShopItemSlotWidget::NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
 {
     Super::NativeOnMouseButtonUp(InGeometry, InMouseEvent);
-
-    // 아마 클릭 하면 구매?
 
     return FReply::Handled();
 }
@@ -13,6 +32,8 @@ void UShopItemSlotWidget::NativeOnMouseEnter(const FGeometry& InGeometry, const 
 {
     Super::NativeOnMouseEnter(InGeometry, InMouseEvent);
     // TODO : 시간 측정하고 툴팁 띄우기
+
+
 }
 
 void UShopItemSlotWidget::NativeOnMouseLeave(const FPointerEvent& InMouseEvent)
@@ -20,4 +41,38 @@ void UShopItemSlotWidget::NativeOnMouseLeave(const FPointerEvent& InMouseEvent)
     Super::NativeOnMouseLeave(InMouseEvent);
 
     // TODO : 시간 측정 초기화
+}
+
+void UShopItemSlotWidget::ShowOrNotToolTip(bool bShouldShow)
+{
+    // 나중에 서서히 등장하는 효과를 넣을 수도 있다고 생각해서 Color로
+    FLinearColor Color(1, 1, 1, 1);
+
+    if (bShouldShow)
+    {
+        Color.A = 1;
+        
+    }
+    else
+    {
+        Color.A = 0;
+    }
+
+    ToolTipImage->SetColorAndOpacity(Color);
+}
+
+void UShopItemSlotWidget::SetSlotImage(UTexture2D* NewTexture)
+{
+    if (NewTexture == nullptr)
+    {
+        LOG(TEXT("NewTexture == nullptr"));
+        return;
+    }
+
+    SlotImage->SetBrushFromTexture(NewTexture);
+}
+
+void UShopItemSlotWidget::SetToolTipText(const FString& NewText)
+{
+    ToolTipTextBlock->SetText(FText::FromString(NewText));
 }

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.h
@@ -2,20 +2,64 @@
 
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
+#include "Blueprint/IUserObjectListEntry.h"
 
 #include "ShopItemSlotWidget.generated.h"
 
+
+
+class UImage;
 /**
  * 상점에서 소비템, 장비, 업글 표시하는 슬롯
  */
 UCLASS()
-class ABYSSDIVERUNDERWORLD_API UShopItemSlotWidget : public UUserWidget
+class ABYSSDIVERUNDERWORLD_API UShopItemSlotWidget : public UUserWidget, public IUserObjectListEntry
 {
 	GENERATED_BODY()
 	
 protected:
 
+	virtual void NativeOnListItemObjectSet(UObject* ListItemObject) override;
+
 	virtual FReply NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
 	virtual void NativeOnMouseEnter(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
 	virtual void NativeOnMouseLeave(const FPointerEvent& InMouseEvent) override;
+
+#pragma region Methods, Delegates
+
+
+private:
+
+	void ShowOrNotToolTip(bool bShouldShow);
+
+#pragma endregion
+
+#pragma region Variables
+
+private:
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UImage> SlotImage;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UImage> ToolTipImage;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<class URichTextBlock> ToolTipTextBlock;
+
+	FTimerHandle ToolTipTimerHandle;
+
+#pragma endregion
+
+#pragma region Getters, Setters
+
+public:
+
+	void SetSlotImage(UTexture2D* NewTexture);
+	void SetToolTipText(const FString& NewText);
+
+
+#pragma endregion
+
+
 };

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopTileView.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopTileView.cpp
@@ -1,0 +1,8 @@
+#include "Shops/ShopWidgets/ShopTileView.h"
+
+#include "Shops/ShopItemEntryData.h"
+
+void UShopTileView::SetAllElements(const TArray<UShopItemEntryData*>& Elements)
+{
+	SetListItems(Elements);
+}

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopTileView.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopTileView.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/TileView.h"
+
+#include "ShopTileView.generated.h"
+
+class UShopItemEntryData;
+/**
+ *  상점 아이템 목록 띄우는 위젯
+ */
+UCLASS()
+class ABYSSDIVERUNDERWORLD_API UShopTileView : public UTileView
+{
+	GENERATED_BODY()
+
+
+public:
+
+	void SetAllElements(const TArray<UShopItemEntryData*>& Elements);
+	
+};

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
@@ -2,21 +2,170 @@
 
 #include "ShopCategoryTabWidget.h"
 #include "AbyssDiverUnderWorld.h"
+#include "ShopTileView.h"
+#include "Shops/ShopItemEntryData.h"
 
-UShopCategoryTabWidget* UShopWidget::GetCategoryTab(ECategoryTab CategoryTab) const
+void UShopWidget::NativeConstruct()
 {
-	if (CategoryTab == ECategoryTab::None || CategoryTab == ECategoryTab::MAX)
+	Super::NativeConstruct();
+
+	CurrentActivatedTab = EShopCategoryTab::Consumable;
+
+	ConsumableTab->OnShopCategoryTabClickedDelegate.AddUObject(this, &UShopWidget::OnCategoryTabClicked);
+	EquipmentTab->OnShopCategoryTabClickedDelegate.AddUObject(this, &UShopWidget::OnCategoryTabClicked);
+}
+
+void UShopWidget::SetAllItems(const TArray<UShopItemEntryData*>& EntryDataList, EShopCategoryTab Tab)
+{
+	if (Tab >= EShopCategoryTab::Max)
 	{
-		LOGV(Error, TEXT("Weird Category : %d"), CategoryTab);
+		LOGV(Error, TEXT("Weird Tab Type : %d"), Tab);
+		return;
+	}
+
+	switch (Tab)
+	{
+	case EShopCategoryTab::Consumable:
+		ConsumableTabEntryDataList = EntryDataList;
+		break;
+	case EShopCategoryTab::Equipment:
+		EquipmentTabEntryDataList = EntryDataList;
+		break;
+	case EShopCategoryTab::Upgrade:
+		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		return;
+	case EShopCategoryTab::Max:
+		check(false);
+		return;
+	default:
+		check(false);
+		return;
+	}
+}
+
+void UShopWidget::AddItem(UShopItemEntryData* EntryData, EShopCategoryTab Tab)
+{
+	if (Tab >= EShopCategoryTab::Max)
+	{
+		LOGV(Error, TEXT("Weird Tab Type : %d"), Tab);
+		return;
+	}
+
+	switch (Tab)
+	{
+	case EShopCategoryTab::Consumable:
+		ConsumableTabEntryDataList.Add(EntryData);
+		break;
+	case EShopCategoryTab::Equipment:
+		EquipmentTabEntryDataList.Add(EntryData);
+		break;
+	case EShopCategoryTab::Upgrade:
+		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		return;
+	case EShopCategoryTab::Max:
+		check(false);
+		return;
+	default:
+		check(false);
+		return;
+	}
+}
+
+void UShopWidget::ShowItemViewForTab(EShopCategoryTab TabType)
+{
+	if (TabType >= EShopCategoryTab::Max)
+	{
+		LOGV(Error, TEXT("Weird Tab Type : %d"), TabType);
+		return;
+	}
+
+	if (TabType != CurrentActivatedTab)
+	{
+		SetCurrentActivatedTab(TabType);
+	}
+
+	RefreshItemView();
+}
+
+void UShopWidget::RefreshItemView()
+{
+	check(ItemTileView);
+
+	switch (CurrentActivatedTab)
+	{
+	case EShopCategoryTab::Consumable:
+		ItemTileView->SetAllElements(ConsumableTabEntryDataList);
+		break;
+	case EShopCategoryTab::Equipment:
+		ItemTileView->SetAllElements(EquipmentTabEntryDataList);
+		break;
+	case EShopCategoryTab::Upgrade:
+		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		return;
+	case EShopCategoryTab::Max:
+		check(false);
+		return;
+	default:
+		check(false);
+		return;
+	}
+}
+
+void UShopWidget::OnCategoryTabClicked(EShopCategoryTab CategoryTab)
+{
+	if (CategoryTab >= EShopCategoryTab::Max)
+	{
+		LOGV(Error, TEXT("Weird Tab Type : %d"), CategoryTab);
+		return;
+	}
+
+	ShowItemViewForTab(CategoryTab);
+}
+
+EShopCategoryTab UShopWidget::GetCurrentActivatedTab() const
+{
+	return CurrentActivatedTab;
+}
+
+void UShopWidget::SetCurrentActivatedTab(EShopCategoryTab Tab)
+{
+	if (Tab >= EShopCategoryTab::Max)
+	{
+		LOGV(Error, TEXT("Weird Tab Type : %d"), Tab);
+		return;
+	}
+
+	CurrentActivatedTab = Tab;
+}
+
+UShopCategoryTabWidget* UShopWidget::GetCategoryTab(EShopCategoryTab CategoryTab) const
+{
+	if (CategoryTab >= EShopCategoryTab::Max)
+	{
+		LOGV(Error, TEXT("Weird Tab Type : %d"), CategoryTab);
 		return nullptr;
 	}
 
-	int32 Index = (int32)CategoryTab - 1;
-	if (CategoryTabList.IsValidIndex(Index) == false)
+	UShopCategoryTabWidget* Tab = nullptr;
+
+	switch (CategoryTab)
 	{
-		LOGV(Error, TEXT("Not Valid Index : %d"), Index);
+	case EShopCategoryTab::Consumable:
+		Tab = ConsumableTab;
+		break;
+	case EShopCategoryTab::Equipment:
+		Tab = EquipmentTab;
+		break;
+	case EShopCategoryTab::Upgrade:
+		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		return nullptr;
+	case EShopCategoryTab::Max:
+		check(false);
+		return nullptr;
+	default:
+		check(false);
 		return nullptr;
 	}
 
-	return CategoryTabList[(int32)CategoryTab - 1];
+	return Tab;
 }

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
@@ -6,8 +6,9 @@
 #include "ShopWidget.generated.h"
 
 
-enum class ECategoryTab : uint8;
+enum class EShopCategoryTab : uint8;
 class UShopCategoryTabWidget;
+class UShopItemEntryData;
 /**
  * 
  */
@@ -17,13 +18,63 @@ class ABYSSDIVERUNDERWORLD_API UShopWidget : public UUserWidget
 	GENERATED_BODY()
 
 
-private:
+protected:
 
-	UPROPERTY(EditDefaultsOnly, meta = (AllowPrivateAccess), Category = "ShopWidget")
-	TArray<TObjectPtr<UShopCategoryTabWidget>> CategoryTabList;
+	virtual void NativeConstruct() override;
+
+#pragma region Methods
 
 public:
 
-	UShopCategoryTabWidget* GetCategoryTab(ECategoryTab CategoryTab) const;
+	void SetAllItems(const TArray<UShopItemEntryData*>& EntryDataList, EShopCategoryTab Tab);
+	void AddItem(UShopItemEntryData* EntryData, EShopCategoryTab Tab);
+
+	void ShowItemViewForTab(EShopCategoryTab TabType);
+	void RefreshItemView();
+
+private:
+
+	UFUNCTION()
+	void OnCategoryTabClicked(EShopCategoryTab CategoryTab);
+	
+#pragma endregion
+
+#pragma region Variables
+
+private:
+
+
+	UPROPERTY(EditDefaultsOnly, meta = (BindWidget), meta = (AllowPrivateAccess), Category = "ShopWidget")
+	TObjectPtr<UShopCategoryTabWidget> ConsumableTab;
+
+	UPROPERTY(EditDefaultsOnly, meta = (BindWidget), meta = (AllowPrivateAccess), Category = "ShopWidget")
+	TObjectPtr<UShopCategoryTabWidget> EquipmentTab;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<class UShopTileView> ItemTileView;
+
+	EShopCategoryTab CurrentActivatedTab;
+
+	UPROPERTY()
+	TArray<TObjectPtr<UShopItemEntryData>> ConsumableTabEntryDataList;
+
+	UPROPERTY()
+	TArray<TObjectPtr<UShopItemEntryData>> EquipmentTabEntryDataList;
+
+	const int8 MAX_TAB_COUNT = 3;
+
+#pragma endregion
+
+#pragma region Getters, Setters
+
+public:
+
+	EShopCategoryTab GetCurrentActivatedTab() const;
+	void SetCurrentActivatedTab(EShopCategoryTab Tab);
+
+
+	UShopCategoryTabWidget* GetCategoryTab(EShopCategoryTab CategoryTab) const;
+	
+#pragma endregion
 	
 };


### PR DESCRIPTION
---

## 📝 작업 상세 내용

### ShopCategoryTabWidget
- 탭 전환 버튼 (소비, 장비 탭 등등)

### ShopItemSlotWidget
- Entry 역할, TileView에 띄우는 타일

### ShopTileView
- 상점 아이템 목록을 TileView로 구현

### ShopWidget
- 상점 Widget 총괄
- Entry 데이터를 받고 위젯 새로고침 역할

### Shop
- 상점이 가지는 아이템 Id 정보를 관리
- 상점 Widget에게 알맞게 명령
- Fast Array Serializer로 아이디 배열 최적화

### ShopItemEntryData
- 상점 아이템 슬롯에 띄울 정보 전달용

---

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4f4e7fac-879e-47d6-b274-f2722d5aa2d9)
참고로 아이템 이름 적혀있는거 ToolTip 자리인데 일단 임시로 띄워둠
완성되면 마우스 올릴 때 추기정보 표시

---

## 🙋 리뷰어에게 요청사항
- 양이 좀 많습니다 ㅈㅅ..

---
