### PR TITLE
Character Gravity 조정, DataTableSubsystem 예외 처리 및 BP 설정

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -2,6 +2,7 @@
 
 [/Script/EngineSettings.GameMapsSettings]
 GameDefaultMap=/Engine/Maps/Templates/OpenWorld
+GameInstanceClass=/Script/AbyssDiverUnderWorld.ADTestGameInstance
 
 [/Script/Engine.RendererSettings]
 r.AllowStaticLighting=False

--- a/Content/_AbyssDiver/Blueprints/Core/BP_TestGameInstance.uasset
+++ b/Content/_AbyssDiver/Blueprints/Core/BP_TestGameInstance.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3208ceb0fdfe2c5f437d4b7c28e3045e045b17673210b7aa4b3f9365ef4c5fc3
+size 6573

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
@@ -20,12 +20,13 @@ AUnderwaterCharacter::AUnderwaterCharacter()
 	FirstPersonCameraComponent->SetupAttachment(GetCapsuleComponent());
 	FirstPersonCameraComponent->SetRelativeLocation(FVector(-10.f, 0.f, 60.f)); // Position the camera
 	FirstPersonCameraComponent->bUsePawnControlRotation = true;
-
+	
 	if (UCharacterMovementComponent* Movement = GetCharacterMovement())
 	{
 		Movement->SetMovementMode(MOVE_Swimming);
 		Movement->MaxSwimSpeed = 400.0f;
 		Movement->BrakingDecelerationSwimming = 500.0f;
+		Movement->GravityScale = 0.0f;
 	}
 
 	// To-Do
@@ -74,6 +75,7 @@ void AUnderwaterCharacter::SetCharacterState(ECharacterState State)
 		GetCharacterMovement()->GetPhysicsVolume()->bWaterVolume = true;
 		GetCharacterMovement()->SetMovementMode(MOVE_Swimming);
 		GetCharacterMovement()->bOrientRotationToMovement = false;
+		GetCharacterMovement()->GravityScale = 0.0f;
 		bUseControllerRotationYaw = true;
 		break;
 	case ECharacterState::Ground:
@@ -81,6 +83,7 @@ void AUnderwaterCharacter::SetCharacterState(ECharacterState State)
 		GetCharacterMovement()->GetPhysicsVolume()->bWaterVolume = false;
 		GetCharacterMovement()->SetMovementMode(MOVE_Walking);
 		GetCharacterMovement()->bOrientRotationToMovement = true;
+		GetCharacterMovement()->GravityScale = 1.0f;
 		bUseControllerRotationYaw = false;
 		break;
 	default:

--- a/Source/AbyssDiverUnderWorld/Subsystems/ADTestGameInstance.h
+++ b/Source/AbyssDiverUnderWorld/Subsystems/ADTestGameInstance.h
@@ -22,10 +22,10 @@ public:
 	UPROPERTY(EditDefaultsOnly, Category = "ADTestGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.FADItemDataRow"))
 	TObjectPtr<UDataTable> ItemDataTable;
 
-	UPROPERTY(EditDefaultsOnly, Category = "ADTestGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.FDropEntry"))
+	UPROPERTY(EditDefaultsOnly, Category = "ADTestGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.DropEntry"))
 	TObjectPtr<UDataTable> OreDropTable;
 
-	UPROPERTY(EditDefaultsOnly, Category = "ADTestGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.FADUpgradeDataRow"))
+	UPROPERTY(EditDefaultsOnly, Category = "ADTestGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.ADUpgradeDataRow"))
 	TObjectPtr<UDataTable> UpgradeDataTable;
 
 #pragma endregion

--- a/Source/AbyssDiverUnderWorld/Subsystems/DataTableSubsystem.cpp
+++ b/Source/AbyssDiverUnderWorld/Subsystems/DataTableSubsystem.cpp
@@ -3,6 +3,7 @@
 #include "Subsystems/ADTestGameInstance.h"
 #include "DataRow/ADUpgradeDataRow.h"
 #include "DataRow/FADItemDataRow.h"
+#include "Interactable/Item/ADOreRock.h"
 
 
 void UDataTableSubsystem::Initialize(FSubsystemCollectionBase& Collection)
@@ -11,9 +12,18 @@ void UDataTableSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 
 	UADTestGameInstance* GI = CastChecked<UADTestGameInstance>(GetGameInstance());
 	//ItemDataTable->GetAllRows<FFADItemDataRow>(TEXT("TestShopItemData"), DataTableArray);
-	GI->ItemDataTable->GetAllRows<FFADItemDataRow>(TEXT("ItemDataTable"), ItemDataTableArray);
-	GI->UpgradeDataTable->GetAllRows<FADUpgradeDataRow>(TEXT("UpgradeDataTable"), UpgradeDataTableArray);
-	GI->OreDropTable->GetAllRows<FDropEntry>(TEXT("OreDropDataTable"), OreDropEntryTableArray);
+	if (UDataTable* ItemDataTable = GI->ItemDataTable)
+	{
+		ItemDataTable->GetAllRows<FFADItemDataRow>(TEXT("ItemDataTable"), ItemDataTableArray);
+	}
+	if (UDataTable* UpgradeDataTable = GI->UpgradeDataTable)
+	{
+		UpgradeDataTable->GetAllRows<FADUpgradeDataRow>(TEXT("UpgradeDataTable"), UpgradeDataTableArray);
+	}
+	if (UDataTable* OreDropTable = GI->OreDropTable)
+	{
+		OreDropTable->GetAllRows<FDropEntry>(TEXT("OreDropDataTable"), OreDropEntryTableArray);
+	}
 
 	Algo::Sort(ItemDataTableArray, [](const FFADItemDataRow* A, const FFADItemDataRow* B)
 		{


### PR DESCRIPTION
---

## 📝 작업 상세 내용
<!-- 어떤 기능을 추가/수정했는지 상세히 기술해주세요 -->
- 수중 캐릭터의 Gravity Scale을 0으로 수정([Feat] 캐릭터 중력 비활성화 요청 #48)
- DataTableSubsystem 예외 처리 추가
    - DataTable을 지정 안 했을 떄 크래시 나는 현상 방지
- BP_TestGameInstance 추가

DataTableSubsystem은 큰 틀만 잡고 세부 작업은 나중에 할려고 했는데 현재 커밋에서 크래시가 발생하는 현상이 있었습니다. 해당 부분만 수정해서 문제 없는 상황으로 수정했고 자세한 로직은 추후에 보완될 예정입니다.

Game Instance 또한 추후에 ADGameInstance가 들어오면 대체될 예정입니다.

---

## 📸 스크린샷 (선택)


---

## 🙋 리뷰어에게 요청사항
- 네이밍이 적절한지 확인 부탁드립니다

---
