### PR TITLE
✨ update 상점 업그레이드시 적용 로직 완성 및 기타

### DIFF
--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ElementInfoPanel.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ElementInfoPanel.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6eea548a9748c597d80eb7922de49aa86655ba1b9c69e455c3170af6e953c355
-size 36532
+oid sha256:ac47a7dd0e2e1c7d9de277cbccbecc60a9ff36a6b467eda44f0f0cbf4801c08c
+size 39893

--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_Shop.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_Shop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6cb48fc4710209c197d87bdf932cd6d62729fc7be748fd55f864bbcea74ba278
-size 45591
+oid sha256:58567238facd377ea2c80767252262f3db66c6ed2258e46b13060e878a1d05ae
+size 52369

--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ShopItemMeshPanel.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ShopItemMeshPanel.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a352fbc4c7b3614d023f747a601051d25dc5d1ee31d46c32c9d0a1cce685c603
+size 28730

--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ShopItemSlot.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ShopItemSlot.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6b316451c0995d43e37a6d5c014b1e328d7b8aaea3d5d73395c25ee9667be40
-size 31551
+oid sha256:e6238449455f8552740f804278415f9ed155086728beeff7becc7a1b0d2f90c1
+size 31541

--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ShopUpgradeSlot.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ShopUpgradeSlot.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ce1b10b70a9dad2540ab2479bd6c890554daadb641baa1647400277b58935ce
+size 33385

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_HSRTestUnderWaterCharacter.uasset
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_HSRTestUnderWaterCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d2bccb7205245c5be4fe001271ce73e75df8a36b7562ae0e2d3807965d882b7
-size 69807
+oid sha256:3059b26c8496a5f5743182175e4335e715c2bfecbc891a61a81b6d7a9e4b36b1
+size 69805

--- a/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.cpp
@@ -7,6 +7,10 @@
 #include "Kismet/GameplayStatics.h"
 #include "Net/UnrealNetwork.h"
 #include "Subsystems/DataTableSubsystem.h"
+#include "Framework/ADPlayerState.h"
+#include "Character/UnderwaterCharacter.h"
+#include "Shops/ShopInteractionComponent.h"
+#include "Shops/Shop.h"
 
 // Sets default values for this component's properties
 UUpgradeComponent::UUpgradeComponent()
@@ -49,10 +53,57 @@ void UUpgradeComponent::GetLifetimeReplicatedProps(TArray<class FLifetimePropert
 	DOREPLIFETIME(UUpgradeComponent, UpgradeGradeMap);
 }
 
+void UUpgradeComponent::S_RequestUpgrade_Implementation(EUpgradeType UpgradeType)
+{
+	bool bIsSucceeded = Upgrade(UpgradeType);
+	if (bIsSucceeded)
+	{
+		OnRep_UpgradeGradeMap();
+	}
+}
+
+void UUpgradeComponent::OnRep_UpgradeGradeMap()
+{
+	AADPlayerState* PS = Cast<AADPlayerState>(GetOwner());
+	if (PS == nullptr)
+	{
+		LOGV(Error, TEXT("PS == nullptr"));
+		return;
+	}
+
+	if (PS->GetPlayerController() != UGameplayStatics::GetPlayerController(GetWorld(), 0))
+	{
+		return;
+	}
+
+	AUnderwaterCharacter* PlayerCharacter = Cast<AUnderwaterCharacter>(PS->GetPlayerController()->GetPawn());
+	if (PlayerCharacter == nullptr)
+	{
+		LOGV(Error, TEXT("PlayerCharacter == nullptr"));
+		return;
+	}
+
+	UShopInteractionComponent* ShopInteractionComp = PlayerCharacter->GetShopInteractionComponent();
+	if (ShopInteractionComp == nullptr)
+	{
+		LOGV(Error, TEXT("ShopInteractionComp == nullptr"));
+		return;
+	}
+
+	AShop* Shop = ShopInteractionComp->GetCurrentInteractingShop();
+	if (Shop == nullptr)
+	{
+		LOGV(Error, TEXT("Shop == nullptr"));
+		return;
+	}
+
+	Shop->InitUpgradeView();
+}
+
 uint8 UUpgradeComponent::GetCurrentGrade(EUpgradeType UpgradeType) const
 {
 	const int32 Index = static_cast<int32>(UpgradeType);
-	return UpgradeGradeMap.IsValidIndex(Index) ? UpgradeGradeMap[Index] : -1;
+	return UpgradeGradeMap.IsValidIndex(Index) ? UpgradeGradeMap[Index] : 0;
 }
 
 bool UUpgradeComponent::Upgrade(EUpgradeType UpgradeType)

--- a/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.cpp
@@ -71,7 +71,7 @@ void UUpgradeComponent::OnRep_UpgradeGradeMap()
 		return;
 	}
 
-	if (PS->GetPlayerController() != UGameplayStatics::GetPlayerController(GetWorld(), 0))
+	if (PS->GetPlayerController()->IsLocalController())
 	{
 		return;
 	}

--- a/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.cpp
@@ -71,7 +71,7 @@ void UUpgradeComponent::OnRep_UpgradeGradeMap()
 		return;
 	}
 
-	if (PS->GetPlayerController()->IsLocalController())
+	if (PS->GetPlayerController()->IsLocalController() == false)
 	{
 		return;
 	}

--- a/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.h
+++ b/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.h
@@ -32,10 +32,21 @@ protected:
 
 #pragma region Method
 
+public:
+
+	UFUNCTION(Server, Unreliable)
+	void S_RequestUpgrade(EUpgradeType UpgradeType);
+	void S_RequestUpgrade_Implementation(EUpgradeType UpgradeType);
+
 protected:
 	
 	UFUNCTION(BlueprintImplementableEvent, meta = (DisplayName = "OnUpgradePerformed"))
 	void K2_OnUpgradePerformed(EUpgradeType UpgradeType, uint8 Grade);
+
+private:
+
+	UFUNCTION()
+	void OnRep_UpgradeGradeMap();
 
 #pragma endregion
 	
@@ -52,7 +63,7 @@ private:
 	TWeakObjectPtr<class UDataTableSubsystem> DataTableSubsystem;
 	
 	/** 현재 Upgrade 정보를 저장한다. Type 별로 Grade를 저장하며 1이 기본값이다. */
-	UPROPERTY(VisibleInstanceOnly, Replicated)
+	UPROPERTY(VisibleInstanceOnly, ReplicatedUsing = OnRep_UpgradeGradeMap)
 	TArray<uint8> UpgradeGradeMap;
 	
 #pragma endregion

--- a/Source/AbyssDiverUnderWorld/Framework/ADPlayerState.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADPlayerState.cpp
@@ -1,16 +1,13 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
-
 #include "Framework/ADPlayerState.h"
 #include "Inventory/ADInventoryComponent.h"
 #include "AbyssDiverUnderWorld.h"
+#include "Character/UpgradeComponent.h"
 
 AADPlayerState::AADPlayerState()
 {
 	InventoryComp = CreateDefaultSubobject<UADInventoryComponent>(TEXT("InventoryComp"));
+	UpgradeComp = CreateDefaultSubobject<UUpgradeComponent>(TEXT("UpgradeComp"));
 }
-
-
 
 void AADPlayerState::BeginPlay()
 {
@@ -21,7 +18,7 @@ void AADPlayerState::BeginPlay()
 	{
 
 		InventoryComp->InventoryInitialize();
-		LOGVN(Error, TEXT("Inventory Initializded"));
+		LOGVN(Log, TEXT("Inventory Initializded"));
 	}
 
 }

--- a/Source/AbyssDiverUnderWorld/Framework/ADPlayerState.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADPlayerState.h
@@ -7,6 +7,7 @@
 #include "ADPlayerState.generated.h"
 
 class UADInventoryComponent;
+class UUpgradeComponent;
 
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API AADPlayerState : public APlayerState
@@ -25,10 +26,16 @@ protected:
 protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
 	TObjectPtr<UADInventoryComponent> InventoryComp;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	TObjectPtr<UUpgradeComponent> UpgradeComp;
+
 #pragma endregion
 	
 #pragma region Getter/Setter
 public:
-	UADInventoryComponent* GetInventory() { return InventoryComp; };
+	FORCEINLINE UADInventoryComponent* GetInventory() const { return InventoryComp; };
+	FORCEINLINE UUpgradeComponent* GetUpgradeComp() const { return UpgradeComp; };
+
 #pragma endregion
 };

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
@@ -1,19 +1,25 @@
-#include "Shops/Shop.h"
+Ôªø#include "Shops/Shop.h"
 
 #include "Character/UnitBase.h"
+#include "Character/UnderwaterCharacter.h"
+#include "Character/UpgradeComponent.h"
+
 #include "Shops/ShopWidgets/ShopCategoryTabWidget.h"
 #include "Shops/ShopWidgets/ShopWidget.h"
 #include "Shops/ShopItemEntryData.h"
 #include "Shops/ShopWidgets/ShopElementInfoWidget.h"
 #include "Shops/ShopWidgets/ShopItemSlotWidget.h"
-#include "AbyssDiverUnderWorld.h"
-#include "Character/UnderwaterCharacter.h"
 #include "ShopInteractionComponent.h"
+
+#include "AbyssDiverUnderWorld.h"
 #include "Framework/ADPlayerState.h"
 #include "Inventory/ADInventoryComponent.h"
 #include "Subsystems/DataTableSubsystem.h"
 
+#include "DataRow/UpgradeDataRow.h"
 #include "DataRow/FADItemDataRow.h"
+
+
 #include "Net/UnrealNetwork.h"
 #include "Kismet/GameplayStatics.h"
 
@@ -145,6 +151,7 @@ AShop::AShop()
 	InteractableComp = CreateDefaultSubobject<UADInteractableComponent>(TEXT("InteractableComp"));
 
 	bIsOpened = false;
+	CurrentSelectedUpgradeType = EUpgradeType::Max;
 }
 
 void AShop::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
@@ -176,7 +183,7 @@ void AShop::Interact_Implementation(AActor* InstigatorActor)
 		return;
 	}
 
-	// ƒ≥∏Ø≈Õ∑Œ∫Œ≈Õ ƒƒ∆˜≥Õ∆Æ Get, ≥™¡ﬂø° Getter∑Œ ∞°¡Æø»
+	// Ï∫êÎ¶≠ÌÑ∞Î°úÎ∂ÄÌÑ∞ Ïª¥Ìè¨ÎÑåÌä∏ Get, ÎÇòÏ§ëÏóê GetterÎ°ú Í∞ÄÏ†∏Ïò¥
 	UShopInteractionComponent* ShopInteractionComp = InteractingCharacter->FindComponentByClass<UShopInteractionComponent>();
 	if (ShopInteractionComp == nullptr)
 	{
@@ -200,6 +207,7 @@ void AShop::OpenShop(AUnderwaterCharacter* Requester)
 		return;
 	}
 
+	InitUpgradeView();
 	ShopWidget->AddToViewport();
 
 	APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
@@ -236,7 +244,7 @@ EBuyResult AShop::BuyItem(uint8 ItemId, AUnderwaterCharacter* Buyer)
 		return EBuyResult::HasNoAuthority;
 	}
 
-	/*if (µ∑¿Ã æ¯¿∏∏È)
+	/*if (ÎèàÏù¥ ÏóÜÏúºÎ©¥)
 	{
 		return EBuyResult::NotEnoughMoney;
 	}*/
@@ -272,8 +280,8 @@ EBuyResult AShop::BuyItem(uint8 ItemId, AUnderwaterCharacter* Buyer)
 
 	PS->GetInventory()->AddInventoryItem(ItemData);
 
-	// µ∑ ¬˜∞® ∑Œ¡˜
-	// ¿Œ∫•≈‰∏Æø° æ∆¿Ã≈€ ≥÷±‚
+	// Îèà Ï∞®Í∞ê Î°úÏßÅ
+	// Ïù∏Î≤§ÌÜ†Î¶¨Ïóê ÏïÑÏù¥ÌÖú ÎÑ£Í∏∞
 	LOGV(Log, TEXT("Buying Item Succeeded : %s"), *ItemDataRow->Name.ToString());
 	return EBuyResult::Succeeded;
 }
@@ -286,13 +294,13 @@ ESellResult AShop::SellItem(uint8 ItemId, AUnderwaterCharacter* Seller)
 		return ESellResult::HasNoAuthority;
 	}
 
-	/*if (æ∆¿Ã≈€ æ» ∞Æ∞Ì ¿÷¿∏∏È)
+	/*if (ÏïÑÏù¥ÌÖú Ïïà Í∞ñÍ≥† ÏûàÏúºÎ©¥)
 	{
 		return ESellResult::NotExistItem;
 	}*/
 
-	// µ∑ √ﬂ∞°
-	// ¿Œ∫•≈‰∏Æø°º≠ æ∆¿Ã≈€ ªË¡¶
+	// Îèà Ï∂îÍ∞Ä
+	// Ïù∏Î≤§ÌÜ†Î¶¨ÏóêÏÑú ÏïÑÏù¥ÌÖú ÏÇ≠Ï†ú
 
 	return ESellResult::Succeeded;
 }
@@ -338,7 +346,7 @@ void AShop::AddItemToList(uint8 ItemId, EShopCategoryTab TabType)
 		SlotIndex = ShopEquipmentItemIdList.IdList.Num() - 1;
 		break;
 	case EShopCategoryTab::Upgrade:
-		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		LOGV(Error, TEXT("Can't Add Item to Upgrade Tab"));
 		return;
 	case EShopCategoryTab::Max:
 		check(false);
@@ -361,18 +369,18 @@ void AShop::AddItemToList(uint8 ItemId, EShopCategoryTab TabType)
 	}
 
 	UShopItemEntryData* EntryData = NewObject<UShopItemEntryData>();
-	EntryData->Init(SlotIndex, ItemDataRow->Thumbnail, ItemDataRow->Description); // ¿”Ω√
+	EntryData->Init(SlotIndex, ItemDataRow->Thumbnail, ItemDataRow->Description); // ÏûÑÏãú
 	EntryData->OnEntryUpdatedFromDataDelegate.AddUObject(this, &AShop::OnSlotEntryWidgetUpdated);
 
 	ShopWidget->AddItem(EntryData, TabType);
 
 	if (TabType == EShopCategoryTab::Consumable)
 	{
-		LOGVN(Error, TEXT("ItemAdded to Consumable Tab, Index : %d"), SlotIndex);
+		LOGVN(Log, TEXT("ItemAdded to Consumable Tab, Index : %d"), SlotIndex);
 	}
 	else
 	{
-		LOGVN(Error, TEXT("ItemAdded to Equipment Tab, Index : %d"), SlotIndex);
+		LOGVN(Log, TEXT("ItemAdded to Equipment Tab, Index : %d"), SlotIndex);
 	}
 	
 }
@@ -402,7 +410,7 @@ void AShop::RemoveItemToList(uint8 ItemId, EShopCategoryTab TabType)
 		RemovedIndex = ShopEquipmentItemIdList.Remove(ItemId);
 		break;
 	case EShopCategoryTab::Upgrade:
-		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		LOGV(Error, TEXT("Can't Remove Item From Upgrade Tab"));
 		break;
 	case EShopCategoryTab::Max:
 		check(false);
@@ -418,6 +426,99 @@ void AShop::RemoveItemToList(uint8 ItemId, EShopCategoryTab TabType)
 	}
 
 	ShopWidget->RemoveItem(RemovedIndex, TabType);
+}
+
+void AShop::InitUpgradeView()
+{
+	APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
+
+	AADPlayerState* PS = PC->GetPlayerState<AADPlayerState>();
+	if (PS == nullptr)
+	{
+		LOGV(Error, TEXT("PS == nullptr"));
+		return;
+	}
+
+	// ÎÇòÏ§ëÏóê GetÏúºÎ°ú ÎåÄÏ≤¥
+	UUpgradeComponent* UpgradeComp = PS->GetUpgradeComp();
+	if (UpgradeComp == nullptr)
+	{
+		LOGV(Error, TEXT("UpgradeComp == nullptr"));
+		return;
+	}
+
+	UEnum* UpgradeTypeEnum = StaticEnum<EUpgradeType>();
+	if (UpgradeTypeEnum == nullptr)
+	{
+		LOGV(Error, TEXT("Cant Find Enum"));
+		return;
+	}
+
+	UDataTableSubsystem* DataTableSubsystem = GetGameInstance()->GetSubsystem<UDataTableSubsystem>();
+	if (DataTableSubsystem == nullptr)
+	{
+		LOGV(Error, TEXT("DataTableSubsystem == nullptr"));
+		return;
+	}
+
+	// ÎßàÏßÄÎßâ Í∞íÏùÄ Ìï≠ÏÉÅ EUpgradeType_MAXÏù¥ ÏûêÎèôÏÉùÏÑ±ÎêúÎã§Í≥† Ìï®.(ÏÑ†Ïñ∏Ìïú MAXÎ•º ÎßêÌïòÎäîÍ≤å ÏïÑÎãò)
+	int32 EnumCount = UpgradeTypeEnum->NumEnums() - 1;
+
+	if (CachedUpgradeGradeMap.Num() != EnumCount)
+	{
+		CachedUpgradeGradeMap.Init(-1, EnumCount);
+	}
+
+	bool bHasChanged = false;
+
+	TArray<TObjectPtr<UShopItemEntryData>>& UpgradeTabEntryDataList = ShopWidget->GetUpgradeTabEntryDataList();
+	if (UpgradeTabEntryDataList.Num() <= EnumCount)
+	{
+		UpgradeTabEntryDataList.SetNum(EnumCount);
+	}
+
+	LOGV(Error, TEXT("Enumcount : %d"), EnumCount);
+	for (int32 i = 0; i < EnumCount - 1; ++i) // -1ÏùÄ MAX Ï†úÏô∏
+	{
+		EUpgradeType UpgradeType = EUpgradeType(i);
+		uint8 Grade = UpgradeComp->GetCurrentGrade(UpgradeType);
+
+		if (Grade == 0)
+		{
+			LOGVN(Error, TEXT("Weird Grade Detected, Type : %d"), UpgradeType);
+			return;
+		}
+
+		if (CachedUpgradeGradeMap[i] == Grade)
+		{
+			LOGV(Error, TEXT("UpgradeState : UpgradeType(%d) - Grade(%d)"), UpgradeType, Grade);
+			continue;
+		}
+		LOGV(Error, TEXT("UpgradeState(Renewed) : UpgradeType(%d) - Grade(%d)"), UpgradeType, Grade);
+		CachedUpgradeGradeMap[i] = Grade;
+
+		FUpgradeDataRow* UpgradeDataRow = DataTableSubsystem->GetUpgradeData(UpgradeType, Grade);
+
+		UShopItemEntryData* UpgradeEntryData = NewObject<UShopItemEntryData>();
+		UpgradeEntryData->Init(i, nullptr, FString(TEXT("Temp Tooltip")));
+		UpgradeEntryData->OnEntryUpdatedFromDataDelegate.AddUObject(this, &AShop::OnSlotEntryWidgetUpdated);
+		UpgradeTabEntryDataList[i] = UpgradeEntryData;
+
+		bHasChanged = true;
+	}
+
+	if (bHasChanged == false)
+	{
+		return;
+	}
+
+	if (ShopWidget->GetCurrentActivatedTab() != EShopCategoryTab::Upgrade)
+	{
+		return;
+	}
+
+	ShopWidget->RefreshItemView();
+	OnUpgradeSlotEntryClicked(int32(CurrentSelectedUpgradeType));
 }
 
 void AShop::Interact_Test(AActor* InstigatorActor)
@@ -482,6 +583,11 @@ void AShop::OnShopItemListChanged(const FShopItemListChangeInfo& Info)
 		return;
 	}
 
+	if (Info.ShopTab >= EShopCategoryTab::Upgrade)
+	{
+		return;
+	}
+
 	UShopItemEntryData* EntryData = nullptr;
 	FFADItemDataRow* ItemDataRow = GetGameInstance()->GetSubsystem<UDataTableSubsystem>()->GetItemData(Info.ItemIdAfter);
 	if (ItemDataRow == nullptr)
@@ -495,7 +601,7 @@ void AShop::OnShopItemListChanged(const FShopItemListChangeInfo& Info)
 	case EShopItemChangeType::Added:
 
 		EntryData = NewObject<UShopItemEntryData>();
-		EntryData->Init(Info.ShopIndex, ItemDataRow->Thumbnail, ItemDataRow->Description); // ¿”Ω√
+		EntryData->Init(Info.ShopIndex, ItemDataRow->Thumbnail, ItemDataRow->Description); // ÏûÑÏãú
 		EntryData->OnEntryUpdatedFromDataDelegate.AddUObject(this, &AShop::OnSlotEntryWidgetUpdated);
 		
 		ShopWidget->AddItem(EntryData, Info.ShopTab);
@@ -521,7 +627,6 @@ void AShop::OnShopItemListChanged(const FShopItemListChangeInfo& Info)
 void AShop::OnSlotEntryWidgetUpdated(UShopItemSlotWidget* SlotEntryWidget)
 {
 	SlotEntryWidget->OnShopItemSlotWidgetClickedDelegate.BindUObject(this, &AShop::OnSlotEntryClicked);
-	LOG(TEXT("%s bind Finc"), *SlotEntryWidget->GetName());
 }
 
 void AShop::OnSlotEntryClicked(int32 ClickedSlotIndex)
@@ -545,7 +650,8 @@ void AShop::OnSlotEntryClicked(int32 ClickedSlotIndex)
 		ItemId = ShopEquipmentItemIdList.IdList[ClickedSlotIndex].Id;
 		break;
 	case EShopCategoryTab::Upgrade:
-		LOGV(Error, TEXT("Upgrade is Not Supported Tab Type"));
+		LOGV(Error, TEXT("UpgradeSlot Click!, Index : %d"), ClickedSlotIndex);
+		OnUpgradeSlotEntryClicked(ClickedSlotIndex);
 		return;
 	case EShopCategoryTab::Max:
 		check(false);
@@ -565,15 +671,41 @@ void AShop::OnSlotEntryClicked(int32 ClickedSlotIndex)
 	USkeletalMesh* ItemMesh = ItemDataRow->SkeletalMesh;
 
 	ShopWidget->ShowItemInfos(ItemMesh, ItemDataRow->Description, ItemDataRow->Description);
-	LOG(TEXT("Showing Item Infos..., id : %d"), ItemId);
+	LOGV(Log, TEXT("Showing Item Infos..., id : %d"), ItemId);
 	CurrentSelectedItemId = ItemId;
 }
 
 void AShop::OnBuyButtonClicked()
 {
-	// º≠πˆø° ±∏∏≈ ø‰√ª
-	// æ∆∏∂ «√∑π¿ÃæÓ ƒ≥∏Ø≈Õ≥™ ƒ¡∆Æ∑—∑Øø° ∞¸∑√ ƒƒ∆˜≥Õ∆Æ∏¶ ∏∏µÈ∞Ì Server RPC Ω˜º≠ ø‰√ª«ÿæﬂ «œ¡ˆ æ ¿ª±Ó
-	// ªÛ¡°¿ª ø≠∏È æ∆∏∂ ±◊¬  ƒƒ∆˜≥Õ∆Æø° ªÛ¡°¿ª ƒ≥ΩÃ«ÿµŒ∞Ì(º≠πˆø°º≠) Buy¥©∏£∏È RPC∞° ø¿¥œ±Ó ±◊∂ß ƒ≥ΩÃ«— ªÛ¡°ø°º≠ æ∆¿Ã≈€ ±∏∏≈ Ω√µµ 
+	EShopCategoryTab CurrentTab = ShopWidget->GetCurrentActivatedTab();
+
+	if (CurrentTab == EShopCategoryTab::Upgrade)
+	{
+		APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
+		AADPlayerState* PS = PC->GetPlayerState<AADPlayerState>();
+		if (PS == nullptr)
+		{
+			LOGV(Error, TEXT("PS == nullptr"));
+			return;
+		}
+
+		UUpgradeComponent* UpgradeComp = PS->GetUpgradeComp();
+		if (UpgradeComp == nullptr)
+		{
+			LOGV(Error, TEXT("UpgradeComp == nullptr"));
+			return;
+		}
+
+		bool bIsMaxGrade = UpgradeComp->IsMaxGrade(CurrentSelectedUpgradeType);
+		if (bIsMaxGrade)
+		{
+			LOGV(Log, TEXT("This Upgrade Type Has Reached to Max Level"));
+			return;
+		}
+
+		UpgradeComp->S_RequestUpgrade(CurrentSelectedUpgradeType);
+		return;
+	}
 
 	AUnderwaterCharacter* BuyingCharacter = Cast<AUnderwaterCharacter>(UGameplayStatics::GetPlayerController(GetWorld(), 0)->GetPawn());
 	if (BuyingCharacter == nullptr)
@@ -602,6 +734,48 @@ void AShop::OnCloseButtonClicked()
 	}
 
 	CloseShop(Requester);
+}
+
+void AShop::OnUpgradeSlotEntryClicked(int32 ClickedSlotIndex)
+{
+	APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
+	AADPlayerState* PS = PC->GetPlayerState<AADPlayerState>();
+	if (PS == nullptr)
+	{
+		LOGV(Error, TEXT("PS == nullptr"));
+		return;
+	}
+
+	UUpgradeComponent* UpgradeComp = PS->GetUpgradeComp();
+	if (UpgradeComp == nullptr)
+	{
+		LOGV(Error, TEXT("UpgradeComp == nullptr"));
+		return;
+	}
+
+	EUpgradeType UpgradeType = EUpgradeType(ClickedSlotIndex);
+	
+	uint8 CurrentGrade = UpgradeComp->GetCurrentGrade(UpgradeType);
+	if (CurrentGrade == 0)
+	{
+		LOGV(Log, TEXT("Weird Upgrade Type Detected : %d"), UpgradeType);
+		return;
+	}
+
+	UDataTableSubsystem* DataTableSubSystem = GetGameInstance()->GetSubsystem<UDataTableSubsystem>();
+	if (DataTableSubSystem == nullptr)
+	{
+		LOGV(Error, TEXT("DataTableSubSystem == nullptr"));
+		return;
+	}
+
+	bool bIsMaxGrade = UpgradeComp->IsMaxGrade(UpgradeType);
+
+	FUpgradeDataRow* UpgradeDataRow = DataTableSubSystem->GetUpgradeData(UpgradeType, CurrentGrade);
+	ShopWidget->ShowUpgradeInfos(nullptr, CurrentGrade, bIsMaxGrade, UpgradeDataRow->Price, TEXT("ÏûÑÏãú ÌÖçÏä§Ìä∏"));
+	CurrentSelectedUpgradeType = UpgradeType;
+	//UpgradeComp->S_RequestUpgrade(UpgradeType);
+	LOGV(Log, TEXT("UpgradeViewSlotClicked, Index : %d"), ClickedSlotIndex);
 }
 
 bool AShop::HasItem(int32 ItemId)

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.h
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.h
@@ -50,6 +50,7 @@ struct FFADItemDataRow;
 struct FShopItemIdList;
 
 enum class EShopCategoryTab : uint8;
+enum class EUpgradeType : uint8;
 
 #pragma region FastArraySerializer
 
@@ -174,6 +175,8 @@ public:
 	void AddItemToList(uint8 ItemId, EShopCategoryTab TabType);
 	void RemoveItemToList(uint8 ItemId, EShopCategoryTab TabType);
 
+	void InitUpgradeView();
+
 	// 테스트용, 캐릭터의 Interact를 대신함.
 	UFUNCTION(BlueprintCallable, Category = "Shop", CallInEditor)
 	void Interact_Test(AActor* InstigatorActor);
@@ -198,6 +201,7 @@ private:
 	void OnBuyButtonClicked();
 
 	void OnCloseButtonClicked();
+	void OnUpgradeSlotEntryClicked(int32 ClickedSlotIndex);
 
 #pragma endregion
 
@@ -234,7 +238,11 @@ protected:
 
 private:
 
+	UPROPERTY()
+	TArray<uint8> CachedUpgradeGradeMap;
+
 	int32 CurrentSelectedItemId = INDEX_NONE;
+	EUpgradeType CurrentSelectedUpgradeType;
 	uint8 bIsOpened : 1;
 
 #pragma endregion

--- a/Source/AbyssDiverUnderWorld/Shops/ShopItemEntryData.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopItemEntryData.h
@@ -18,7 +18,7 @@ class ABYSSDIVERUNDERWORLD_API UShopItemEntryData : public UObject
 
 public:
 
-	void Init(int32 NewlotIndex, UTexture2D* NewItemImage, const FString& NewToolTipText);
+	void Init(int32 NewSlotIndex, UTexture2D* NewItemImage, const FString& NewToolTipText);
 
 	FOnEntryUpdatedFromDataDelegate OnEntryUpdatedFromDataDelegate;
 

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopCategoryTabWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopCategoryTabWidget.cpp
@@ -6,7 +6,10 @@
 
 void UShopCategoryTabWidget::NativeConstruct()
 {
-	TabButton->OnClicked.AddDynamic(this, &UShopCategoryTabWidget::OnCategoryButtonClicked);
+	if (TabButton->OnClicked.IsBound() == false)
+	{
+		TabButton->OnClicked.AddDynamic(this, &UShopCategoryTabWidget::OnCategoryButtonClicked);
+	}
 }
 
 void UShopCategoryTabWidget::OnCategoryButtonClicked()

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.cpp
@@ -1,16 +1,21 @@
-#include "ShopElementInfoWidget.h"
+﻿#include "ShopElementInfoWidget.h"
+
+#include "Shops/ShopWidgets/ShopItemMeshPanel.h"
 
 #include "Components/RichTextBlock.h"
 #include "Components/Button.h"
 
 void UShopElementInfoWidget::NativeConstruct()
 {
-	BuyButton->OnClicked.AddDynamic(this, &UShopElementInfoWidget::OnBuyButtonClicked);
+	if (BuyButton->OnClicked.IsBound() == false)
+	{
+		BuyButton->OnClicked.AddDynamic(this, &UShopElementInfoWidget::OnBuyButtonClicked);
+	}
 }
 
 void UShopElementInfoWidget::Init(USkeletalMeshComponent* NewItemMeshComp)
 {
-	ItemMeshComponent = NewItemMeshComp;
+	ItemMeshPanel->Init(NewItemMeshComp);
 }
 
 void UShopElementInfoWidget::ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewInfoText)
@@ -19,10 +24,26 @@ void UShopElementInfoWidget::ShowItemInfos(USkeletalMesh* NewItemMesh, const FSt
 	SetDescriptionActive(true);
 	SetInfoTextActive(true);
 	SetBuyButtonActive(true);
+	SetUpgradeLevelInfoActive(false);
+	SetUpgradeCostInfo(false);
 
 	ChangeItemMesh(NewItemMesh);
 	ChangeItemDescription(NewDescription);
 	ChangeInfoText(NewInfoText);
+}
+
+void UShopElementInfoWidget::ShowUpgradeInfos(USkeletalMesh* NewUpgradeItemMesh, int32 CurrentUpgradeLevel, bool bIsMaxLevel, int32 CurrentUpgradeCost, const FString& ExtraInfoText)
+{
+	SetItemMeshActive(true);
+	SetDescriptionActive(false);
+	SetInfoTextActive(false);
+	SetBuyButtonActive(true);
+	SetUpgradeLevelInfoActive(true);
+	SetUpgradeCostInfo(true);
+
+	ChangeItemMesh(NewUpgradeItemMesh);
+	ChangeUpgradeLevelInfo(CurrentUpgradeLevel, bIsMaxLevel);
+	ChangeUpgradeCostInfo(CurrentUpgradeCost);
 }
 
 void UShopElementInfoWidget::ChangeItemDescription(const FString& NewDescription)
@@ -37,9 +58,34 @@ void UShopElementInfoWidget::ChangeInfoText(const FString& NewInfoText)
 
 void UShopElementInfoWidget::ChangeItemMesh(USkeletalMesh* NewMesh)
 {
-	check(ItemMeshComponent);
+	ItemMeshPanel->ChangeItemMesh(NewMesh);
+}
 
-	ItemMeshComponent->SetSkeletalMesh(NewMesh);
+void UShopElementInfoWidget::ChangeUpgradeLevelInfo(int32 CurrentLevel, bool bIsMaxLevel)
+{
+	FString NewInfoText = FString::FromInt(CurrentLevel);
+
+	if (bIsMaxLevel)
+	{
+		NewInfoText += TEXT("Lv (Max)");
+	}
+	else
+	{
+		NewInfoText += TEXT("Lv -> ");
+		NewInfoText += FString::FromInt(CurrentLevel + 1);
+		NewInfoText += TEXT("Lv");
+	}
+
+	UpgradeLevelInfoText->SetText(FText::FromString(NewInfoText));
+}
+
+void UShopElementInfoWidget::ChangeUpgradeCostInfo(int32 CurrentUpgradeCost)
+{
+	FString NewInfoText = TEXT("업그레이드 비용 ");
+	NewInfoText += FString::FromInt(CurrentUpgradeCost);
+	NewInfoText += TEXT("Cr");
+
+	UpgradeCostInfoText->SetText(FText::FromString(NewInfoText));
 }
 
 void UShopElementInfoWidget::SetDescriptionActive(bool bShouldActivate)
@@ -68,8 +114,7 @@ void UShopElementInfoWidget::SetInfoTextActive(bool bShouldActivate)
 
 void UShopElementInfoWidget::SetItemMeshActive(bool bShouldActivate)
 {
-	check(ItemMeshComponent);
-	ItemMeshComponent->SetActive(bShouldActivate);
+	ItemMeshPanel->SetItemMeshActive(bShouldActivate);
 }
 
 void UShopElementInfoWidget::SetBuyButtonActive(bool bShouldActivate)
@@ -81,6 +126,30 @@ void UShopElementInfoWidget::SetBuyButtonActive(bool bShouldActivate)
 	else
 	{
 		BuyButton->SetVisibility(ESlateVisibility::Hidden);
+	}
+}
+
+void UShopElementInfoWidget::SetUpgradeLevelInfoActive(bool bShouldActivate)
+{
+	if (bShouldActivate)
+	{
+		UpgradeLevelInfoText->SetVisibility(ESlateVisibility::HitTestInvisible);
+	}
+	else
+	{
+		UpgradeLevelInfoText->SetVisibility(ESlateVisibility::Hidden);
+	}
+}
+
+void UShopElementInfoWidget::SetUpgradeCostInfo(bool bShouldActivate)
+{
+	if (bShouldActivate)
+	{
+		UpgradeCostInfoText->SetVisibility(ESlateVisibility::HitTestInvisible);
+	}
+	else
+	{
+		UpgradeCostInfoText->SetVisibility(ESlateVisibility::Hidden);
 	}
 }
 

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.h
@@ -27,15 +27,22 @@ public:
 	void Init(USkeletalMeshComponent* NewItemMeshComp);
 
 	void ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewInfoText);
+	void ShowUpgradeInfos(USkeletalMesh* NewUpgradeItemMesh, int32 CurrentUpgradeLevel, bool bIsMaxLevel, int32 CurrentUpgradeCost, const FString& ExtraInfoText);
 
 	void ChangeItemDescription(const FString& NewDescription);
 	void ChangeInfoText(const FString& NewInfoText);
 	void ChangeItemMesh(USkeletalMesh* NewMesh);
 
+	void ChangeUpgradeLevelInfo(int32 CurrentLevel, bool bIsMaxLevel);
+	void ChangeUpgradeCostInfo(int32 CurrentUpgradeCost);
+
 	void SetDescriptionActive(bool bShouldActivate);
 	void SetInfoTextActive(bool bShouldActivate);
 	void SetItemMeshActive(bool bShouldActivate);
 	void SetBuyButtonActive(bool bShouldActivate);
+
+	void SetUpgradeLevelInfoActive(bool bShouldActivate);
+	void SetUpgradeCostInfo(bool bShouldActivate);
 
 	FOnBuyButtonClickedDelegate OnBuyButtonClickedDelegate;
 
@@ -43,17 +50,12 @@ private:
 
 	UFUNCTION()
 	void OnBuyButtonClicked();
+
 #pragma endregion
 
 #pragma region Variables
 
 protected:
-
-	UPROPERTY()
-	TObjectPtr<USkeletalMeshComponent> ItemMeshComponent;
-
-	UPROPERTY(meta = (BindWidget))
-	TObjectPtr<class UImage> ItemMeshImage;
 
 	UPROPERTY(meta = (BindWidget))
 	TObjectPtr<URichTextBlock> DescriptionText;
@@ -62,7 +64,16 @@ protected:
 	TObjectPtr<URichTextBlock> InfoText;
 
 	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<URichTextBlock> UpgradeLevelInfoText;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<URichTextBlock> UpgradeCostInfoText;
+
+	UPROPERTY(meta = (BindWidget))
 	TObjectPtr<class UButton> BuyButton;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<class UShopItemMeshPanel> ItemMeshPanel;
 
 #pragma endregion
 };

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemMeshPanel.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemMeshPanel.cpp
@@ -1,0 +1,37 @@
+#include "Shops/ShopWidgets/ShopItemMeshPanel.h"
+
+#include "AbyssDiverUnderWorld.h"
+
+FReply UShopItemMeshPanel::NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
+{
+	FReply Reply = Super::NativeOnMouseButtonDown(InGeometry, InMouseEvent);
+
+	return Reply;
+}
+
+FReply UShopItemMeshPanel::NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
+{
+	return Super::NativeOnMouseButtonUp(InGeometry, InMouseEvent);
+}
+
+FReply UShopItemMeshPanel::NativeOnMouseMove(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
+{
+	return Super::NativeOnMouseMove(InGeometry, InMouseEvent);
+}
+
+void UShopItemMeshPanel::Init(USkeletalMeshComponent* NewItemMeshComp)
+{
+	ItemMeshComponent = NewItemMeshComp;
+}
+
+void UShopItemMeshPanel::ChangeItemMesh(USkeletalMesh* NewMesh)
+{
+	check(ItemMeshComponent);
+	ItemMeshComponent->SetSkeletalMesh(NewMesh);
+}
+
+void UShopItemMeshPanel::SetItemMeshActive(bool bShouldActivate)
+{
+	check(ItemMeshComponent);
+	ItemMeshComponent->SetActive(bShouldActivate);
+}

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemMeshPanel.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemMeshPanel.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+
+#include "ShopItemMeshPanel.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ABYSSDIVERUNDERWORLD_API UShopItemMeshPanel : public UUserWidget
+{
+	GENERATED_BODY()
+
+protected:
+
+	virtual FReply NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
+	virtual FReply NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
+	virtual FReply NativeOnMouseMove(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
+
+#pragma region Methods
+
+public:
+
+	void Init(USkeletalMeshComponent* NewItemMeshComp);
+	void ChangeItemMesh(USkeletalMesh* NewMesh);
+
+	void SetItemMeshActive(bool bShouldActivate);
+
+#pragma endregion
+
+#pragma region Variables
+
+private:
+
+	UPROPERTY()
+	TObjectPtr<USkeletalMeshComponent> ItemMeshComponent;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<class UImage> ItemMeshImage;
+
+#pragma endregion
+
+};

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.cpp
@@ -13,7 +13,7 @@ void UShopItemSlotWidget::NativeOnListItemObjectSet(UObject* ListItemObject)
     UShopItemEntryData* EntryData = Cast<UShopItemEntryData>(ListItemObject);
     if (EntryData == nullptr)
     {
-        LOG(TEXT("EntryData == nullptr"));
+        LOGV(Error, TEXT("EntryData == nullptr"));
         return;
     }
 
@@ -22,14 +22,14 @@ void UShopItemSlotWidget::NativeOnListItemObjectSet(UObject* ListItemObject)
     SlotIndex = EntryData->GetSlotIndex();
 
     EntryData->OnEntryUpdatedFromDataDelegate.Broadcast(this);
-    LOG(TEXT("%s - EntryUpdated, Index : %d"), *GetName(), SlotIndex);
+    LOGV(Log, TEXT("%s - EntryUpdated, Index : %d"), *GetName(), SlotIndex);
 }
 
 FReply UShopItemSlotWidget::NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
 {
     FReply Replay =  Super::NativeOnMouseButtonUp(InGeometry, InMouseEvent);
 
-    LOG(TEXT("ShopItemSlotWidgetClicked, Index : %d"), SlotIndex);
+    LOGV(Warning, TEXT("ShopItemSlotWidgetClicked, Index : %d"), SlotIndex);
     OnShopItemSlotWidgetClickedDelegate.ExecuteIfBound(SlotIndex);
 
     return Replay;
@@ -72,7 +72,7 @@ void UShopItemSlotWidget::SetSlotImage(UTexture2D* NewTexture)
 {
     if (NewTexture == nullptr)
     {
-        LOG(TEXT("NewTexture == nullptr"));
+        LOGV(Warning, TEXT("NewTexture == nullptr"));
         return;
     }
 

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
@@ -5,7 +5,14 @@
 #include "ShopTileView.h"
 #include "Shops/ShopItemEntryData.h"
 #include "Shops/ShopWidgets/ShopElementInfoWidget.h"
+
+#include "Character/UnderwaterCharacter.h"
+#include "Character/UpgradeComponent.h"
+#include "DataRow/UpgradeDataRow.h"
+#include "Subsystems/DataTableSubsystem.h"
+
 #include "Components/Button.h"
+#include "Kismet/GameplayStatics.h"
 
 void UShopWidget::NativeConstruct()
 {
@@ -15,7 +22,12 @@ void UShopWidget::NativeConstruct()
 
 	ConsumableTab->OnShopCategoryTabClickedDelegate.AddUObject(this, &UShopWidget::OnCategoryTabClicked);
 	EquipmentTab->OnShopCategoryTabClickedDelegate.AddUObject(this, &UShopWidget::OnCategoryTabClicked);
-	CloseButton->OnClicked.AddDynamic(this, &UShopWidget::OnCloseButtonClicked);
+	UpgradeTab->OnShopCategoryTabClickedDelegate.AddUObject(this, &UShopWidget::OnCategoryTabClicked);
+
+	if (CloseButton->OnClicked.IsBound() == false)
+	{
+		CloseButton->OnClicked.AddDynamic(this, &UShopWidget::OnCloseButtonClicked);
+	}
 }
 
 void UShopWidget::SetAllItems(const TArray<UShopItemEntryData*>& EntryDataList, EShopCategoryTab Tab)
@@ -35,7 +47,7 @@ void UShopWidget::SetAllItems(const TArray<UShopItemEntryData*>& EntryDataList, 
 		EquipmentTabEntryDataList = EntryDataList;
 		break;
 	case EShopCategoryTab::Upgrade:
-		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		UpgradeTabEntryDataList = EntryDataList;
 		return;
 	case EShopCategoryTab::Max:
 		check(false);
@@ -63,7 +75,7 @@ void UShopWidget::AddItem(UShopItemEntryData* EntryData, EShopCategoryTab Tab)
 		EquipmentTabEntryDataList.Add(EntryData);
 		break;
 	case EShopCategoryTab::Upgrade:
-		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		UpgradeTabEntryDataList.Add(EntryData);
 		return;
 	case EShopCategoryTab::Max:
 		check(false);
@@ -91,7 +103,7 @@ void UShopWidget::RemoveItem(int32 Index, EShopCategoryTab Tab)
 		EquipmentTabEntryDataList.RemoveAt(Index);
 		break;
 	case EShopCategoryTab::Upgrade:
-		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		UpgradeTabEntryDataList.RemoveAt(Index);
 		return;
 	case EShopCategoryTab::Max:
 		check(false);
@@ -119,7 +131,7 @@ void UShopWidget::ModifyItem(int32 Index, UTexture2D* NewItemImage, const FStrin
 		EquipmentTabEntryDataList[Index]->Init(Index, NewItemImage, NewToolTipText);
 		break;
 	case EShopCategoryTab::Upgrade:
-		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		UpgradeTabEntryDataList[Index]->Init(Index, NewItemImage, NewToolTipText);
 		return;
 	case EShopCategoryTab::Max:
 		check(false);
@@ -154,12 +166,21 @@ void UShopWidget::RefreshItemView()
 	{
 	case EShopCategoryTab::Consumable:
 		ItemTileView->SetAllElements(ConsumableTabEntryDataList);
+		ItemTileView->SetVisibility(ESlateVisibility::Visible);
+		UpgradeTileView->SetVisibility(ESlateVisibility::Hidden);
+
 		break;
 	case EShopCategoryTab::Equipment:
 		ItemTileView->SetAllElements(EquipmentTabEntryDataList);
+		ItemTileView->SetVisibility(ESlateVisibility::Visible);
+		UpgradeTileView->SetVisibility(ESlateVisibility::Hidden);
+
 		break;
 	case EShopCategoryTab::Upgrade:
-		LOGV(Error, TEXT("Upgrade Tab is not Supported Currently"));
+		UpgradeTileView->SetAllElements(UpgradeTabEntryDataList);
+		UpgradeTileView->SetVisibility(ESlateVisibility::Visible);
+		ItemTileView->SetVisibility(ESlateVisibility::Hidden);
+
 		return;
 	case EShopCategoryTab::Max:
 		check(false);
@@ -173,6 +194,11 @@ void UShopWidget::RefreshItemView()
 void UShopWidget::ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewInfoText)
 {
 	InfoWidget->ShowItemInfos(NewItemMesh, NewDescription, NewInfoText);
+}
+
+void UShopWidget::ShowUpgradeInfos(USkeletalMesh* NewUpgradeItemMesh, int32 CurrentUpgradeLevel, bool bIsMaxLevel, int32 CurrentUpgradeCost, const FString& ExtraInfoText)
+{
+	InfoWidget->ShowUpgradeInfos(NewUpgradeItemMesh, CurrentUpgradeLevel, bIsMaxLevel, CurrentUpgradeCost, ExtraInfoText);
 }
 
 void UShopWidget::OnCategoryTabClicked(EShopCategoryTab CategoryTab)
@@ -243,4 +269,9 @@ UShopElementInfoWidget* UShopWidget::GetInfoWidget() const
 {
 	check(InfoWidget);
 	return InfoWidget;
+}
+
+TArray<TObjectPtr<UShopItemEntryData>>& UShopWidget::GetUpgradeTabEntryDataList()
+{
+	return UpgradeTabEntryDataList;
 }

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
@@ -9,6 +9,7 @@ enum class EShopCategoryTab : uint8;
 class UShopCategoryTabWidget;
 class UShopItemEntryData;
 class UShopElementInfoWidget;
+class UShopTileView;
 
 DECLARE_MULTICAST_DELEGATE(FOnShopCloseButtonClickedDelegate);
 
@@ -38,6 +39,7 @@ public:
 	void RefreshItemView();
 
 	void ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewInfoText);
+	void ShowUpgradeInfos(USkeletalMesh* NewUpgradeItemMesh, int32 CurrentUpgradeLevel, bool bIsMaxLevel, int32 CurrentUpgradeCost, const FString& ExtraInfoText);
 
 	FOnShopCloseButtonClickedDelegate OnShopCloseButtonClickedDelegate;
 
@@ -61,8 +63,14 @@ private:
 	UPROPERTY(EditDefaultsOnly, meta = (BindWidget), meta = (AllowPrivateAccess), Category = "ShopWidget")
 	TObjectPtr<UShopCategoryTabWidget> EquipmentTab;
 
+	UPROPERTY(EditDefaultsOnly, meta = (BindWidget), meta = (AllowPrivateAccess), Category = "ShopWidget")
+	TObjectPtr<UShopCategoryTabWidget> UpgradeTab;
+
 	UPROPERTY(meta = (BindWidget))
-	TObjectPtr<class UShopTileView> ItemTileView;
+	TObjectPtr<UShopTileView> ItemTileView;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UShopTileView> UpgradeTileView;
 
 	UPROPERTY(meta = (BindWidget))
 	TObjectPtr<UShopElementInfoWidget> InfoWidget;
@@ -75,6 +83,9 @@ private:
 
 	UPROPERTY()
 	TArray<TObjectPtr<UShopItemEntryData>> EquipmentTabEntryDataList;
+
+	UPROPERTY()
+	TArray<TObjectPtr<UShopItemEntryData>> UpgradeTabEntryDataList;
 
 	EShopCategoryTab CurrentActivatedTab;
 
@@ -89,10 +100,11 @@ public:
 	EShopCategoryTab GetCurrentActivatedTab() const;
 	void SetCurrentActivatedTab(EShopCategoryTab Tab);
 
-
 	UShopCategoryTabWidget* GetCategoryTab(EShopCategoryTab CategoryTab) const;
 
 	UShopElementInfoWidget* GetInfoWidget() const;
+
+	TArray<TObjectPtr<UShopItemEntryData>>& GetUpgradeTabEntryDataList();
 	
 #pragma endregion
 	


### PR DESCRIPTION

---

## 📝 작업 상세 내용
### 상점 업그레이드시 적용 로직 완성
- UpgradeComponent - 클라이언트의 업그레이드 요청을 받아서 처리하고 다시 클라이언트에게 알림
- 업그레이드 클릭 후 구매 버튼을 누르면 UpgradeComponent를 통해 서버 RPC 호출
- ADPlayerState - UpgradeComponent 소유

### 기타
- 상점에 Item Mesh 드래그로 회전시키는 로직 밑작업

---

---
