### PR TITLE
🐛 bugfix null 체크 제대로 안해서 터지는거 수정;;

### DIFF
--- a/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.cpp
@@ -71,12 +71,18 @@ void UUpgradeComponent::OnRep_UpgradeGradeMap()
 		return;
 	}
 
-	if (PS->GetPlayerController()->IsLocalController() == false)
+	APlayerController* PC = PS->GetPlayerController();
+	if (PC == nullptr)
 	{
 		return;
 	}
 
-	AUnderwaterCharacter* PlayerCharacter = Cast<AUnderwaterCharacter>(PS->GetPlayerController()->GetPawn());
+	if (PC->IsLocalController() == false)
+	{
+		return;
+	}
+
+	AUnderwaterCharacter* PlayerCharacter = Cast<AUnderwaterCharacter>(PC->GetPawn());
 	if (PlayerCharacter == nullptr)
 	{
 		LOGV(Error, TEXT("PlayerCharacter == nullptr"));


### PR DESCRIPTION
---

## 📝 작업 상세 내용

- 클라이언트에서 초기에 PostNetInit이 발동하기 전에 BeginPlay가 호춛될 때 PC가 없어서 터짐. 그래서 null체크
---
