### PR TITLE
✨ update 상점 아이템 메쉬 돌리기 기능 완성 및 기타

### DIFF
--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ElementInfoPanel.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_ElementInfoPanel.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac47a7dd0e2e1c7d9de277cbccbecc60a9ff36a6b467eda44f0f0cbf4801c08c
-size 39893
+oid sha256:e281a956a4d8b388cdaad0fee91ec490af453c46dcc44eaaa7d3525bc3f51074
+size 40891

--- a/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_Shop.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/ShopUI/WBP_Shop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58567238facd377ea2c80767252262f3db66c6ed2258e46b13060e878a1d05ae
-size 52369
+oid sha256:bc6b7589da809c87b12271a6714c81a53309ceb49b063c4affe52f579ce55459
+size 52747

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestShop.uasset
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestShop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aaa7967442052742f8d19cd07d2e97c6d0f3c6b154524c0dd7135f538b8bc7e5
-size 44434
+oid sha256:d074c575d079e4416b3828164b78ba38411eaa6d710f49c80d1fc494cf55d47f
+size 44495

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
@@ -211,7 +211,7 @@ void AShop::OpenShop(AUnderwaterCharacter* Requester)
 	ShopWidget->AddToViewport();
 
 	APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
-	PC->SetInputMode(FInputModeGameAndUI());
+	PC->SetInputMode(FInputModeUIOnly());
 	PC->SetShowMouseCursor(true);
 	bIsOpened = true;
 }
@@ -491,10 +491,10 @@ void AShop::InitUpgradeView()
 
 		if (CachedUpgradeGradeMap[i] == Grade)
 		{
-			LOGV(Error, TEXT("UpgradeState : UpgradeType(%d) - Grade(%d)"), UpgradeType, Grade);
+			LOGV(Log, TEXT("UpgradeState : UpgradeType(%d) - Grade(%d)"), UpgradeType, Grade);
 			continue;
 		}
-		LOGV(Error, TEXT("UpgradeState(Renewed) : UpgradeType(%d) - Grade(%d)"), UpgradeType, Grade);
+		LOGV(Log, TEXT("UpgradeState(Renewed) : UpgradeType(%d) - Grade(%d)"), UpgradeType, Grade);
 		CachedUpgradeGradeMap[i] = Grade;
 
 		FUpgradeDataRow* UpgradeDataRow = DataTableSubsystem->GetUpgradeData(UpgradeType, Grade);
@@ -772,9 +772,10 @@ void AShop::OnUpgradeSlotEntryClicked(int32 ClickedSlotIndex)
 	bool bIsMaxGrade = UpgradeComp->IsMaxGrade(UpgradeType);
 
 	FUpgradeDataRow* UpgradeDataRow = DataTableSubSystem->GetUpgradeData(UpgradeType, CurrentGrade);
-	ShopWidget->ShowUpgradeInfos(nullptr, CurrentGrade, bIsMaxGrade, UpgradeDataRow->Price, TEXT("임시 텍스트"));
+	int32 Price = bIsMaxGrade ? 0 : DataTableSubSystem->GetUpgradeData(UpgradeType, CurrentGrade + 1)->Price;
+	ShopWidget->ShowUpgradeInfos(nullptr, CurrentGrade, bIsMaxGrade, Price, TEXT("임시 텍스트"));
 	CurrentSelectedUpgradeType = UpgradeType;
-	//UpgradeComp->S_RequestUpgrade(UpgradeType);
+
 	LOGV(Log, TEXT("UpgradeViewSlotClicked, Index : %d"), ClickedSlotIndex);
 }
 

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.cpp
@@ -157,3 +157,8 @@ void UShopElementInfoWidget::OnBuyButtonClicked()
 {
 	OnBuyButtonClickedDelegate.Broadcast();
 }
+
+UShopItemMeshPanel* UShopElementInfoWidget::GetItemMeshPanel() const
+{
+	return ItemMeshPanel;
+}

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.h
@@ -6,8 +6,9 @@
 #include "ShopElementInfoWidget.generated.h"
 
 DECLARE_MULTICAST_DELEGATE(FOnBuyButtonClickedDelegate);
-class URichTextBlock;
 
+class URichTextBlock;
+class UShopItemMeshPanel;
 /**
  * 상점에서 아이템, 장비, 업글에 대한 정보를 띄우는 위젯
  */
@@ -73,7 +74,15 @@ protected:
 	TObjectPtr<class UButton> BuyButton;
 
 	UPROPERTY(meta = (BindWidget))
-	TObjectPtr<class UShopItemMeshPanel> ItemMeshPanel;
+	TObjectPtr<UShopItemMeshPanel> ItemMeshPanel;
 
 #pragma endregion
+
+#pragma region Getter / Setter
+
+public:
+	UShopItemMeshPanel* GetItemMeshPanel() const;
+
+#pragma endregion
+
 };

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemMeshPanel.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemMeshPanel.cpp
@@ -4,19 +4,10 @@
 
 FReply UShopItemMeshPanel::NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
 {
-	FReply Reply = Super::NativeOnMouseButtonDown(InGeometry, InMouseEvent);
+	bIsMouseDown = true;
+	CurrentMousePositionX = InMouseEvent.GetScreenSpacePosition().X;
 
-	return Reply;
-}
-
-FReply UShopItemMeshPanel::NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
-{
-	return Super::NativeOnMouseButtonUp(InGeometry, InMouseEvent);
-}
-
-FReply UShopItemMeshPanel::NativeOnMouseMove(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
-{
-	return Super::NativeOnMouseMove(InGeometry, InMouseEvent);
+	return Super::NativeOnMouseButtonDown(InGeometry, InMouseEvent);
 }
 
 void UShopItemMeshPanel::Init(USkeletalMeshComponent* NewItemMeshComp)
@@ -34,4 +25,36 @@ void UShopItemMeshPanel::SetItemMeshActive(bool bShouldActivate)
 {
 	check(ItemMeshComponent);
 	ItemMeshComponent->SetActive(bShouldActivate);
+}
+
+void UShopItemMeshPanel::AddMeshRotationYaw(float Yaw)
+{
+	FRotator NewRotator = ItemMeshComponent->GetComponentRotation();
+	NewRotator.Yaw += Yaw;
+	SetMeshRotation(NewRotator);
+}
+
+void UShopItemMeshPanel::SetMeshRotation(const FRotator& NewRotator)
+{
+	ItemMeshComponent->SetRelativeRotation(NewRotator.Quaternion(), true);
+}
+
+bool UShopItemMeshPanel::GetMouseDown() const
+{
+	return bIsMouseDown;
+}
+
+void UShopItemMeshPanel::SetMouseDown(bool bNewMouseDown)
+{
+	bIsMouseDown = bNewMouseDown;
+}
+
+float UShopItemMeshPanel::GetCurrentMousePositionY() const
+{
+	return CurrentMousePositionX;
+}
+
+void UShopItemMeshPanel::SetCurrentMousePositionX(float NewPositionX)
+{
+	CurrentMousePositionX = NewPositionX;
 }

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemMeshPanel.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemMeshPanel.h
@@ -16,8 +16,6 @@ class ABYSSDIVERUNDERWORLD_API UShopItemMeshPanel : public UUserWidget
 protected:
 
 	virtual FReply NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
-	virtual FReply NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
-	virtual FReply NativeOnMouseMove(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
 
 #pragma region Methods
 
@@ -27,6 +25,9 @@ public:
 	void ChangeItemMesh(USkeletalMesh* NewMesh);
 
 	void SetItemMeshActive(bool bShouldActivate);
+
+	void AddMeshRotationYaw(float Yaw);
+	void SetMeshRotation(const FRotator& NewRotator);
 
 #pragma endregion
 
@@ -40,6 +41,23 @@ private:
 	UPROPERTY(meta = (BindWidget))
 	TObjectPtr<class UImage> ItemMeshImage;
 
+	uint8 bIsMouseDown : 1;
+	
+	float CurrentMousePositionX = 0;
+
 #pragma endregion
+
+#pragma region Getters / Setters
+
+public:
+
+	bool GetMouseDown() const;
+	void SetMouseDown(bool bNewMouseDown);
+
+	float GetCurrentMousePositionY() const;
+	void SetCurrentMousePositionX(float NewPositionX);
+
+#pragma endregion
+
 
 };

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
@@ -5,6 +5,7 @@
 #include "ShopTileView.h"
 #include "Shops/ShopItemEntryData.h"
 #include "Shops/ShopWidgets/ShopElementInfoWidget.h"
+#include "Shops/ShopWidgets/ShopItemMeshPanel.h"
 
 #include "Character/UnderwaterCharacter.h"
 #include "Character/UpgradeComponent.h"
@@ -28,6 +29,33 @@ void UShopWidget::NativeConstruct()
 	{
 		CloseButton->OnClicked.AddDynamic(this, &UShopWidget::OnCloseButtonClicked);
 	}
+}
+
+FReply UShopWidget::NativeOnMouseMove(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
+{
+	UShopItemMeshPanel* MeshPanel = InfoWidget->GetItemMeshPanel();
+
+	if (MeshPanel->GetMouseDown())
+	{
+		float CurrentMouseX = InMouseEvent.GetScreenSpacePosition().X;
+		float MouseX = MeshPanel->GetCurrentMousePositionY();
+		float DeltaX = (MouseX - CurrentMouseX) * MESH_ROTATION_SPEED;
+
+		MeshPanel->SetCurrentMousePositionX(CurrentMouseX);
+		MeshPanel->AddMeshRotationYaw(DeltaX);
+	}
+	
+	return Super::NativeOnMouseMove(InGeometry, InMouseEvent);
+}
+
+FReply UShopWidget::NativeOnKeyDown(const FGeometry& InGeometry, const FKeyEvent& InKeyEvent)
+{
+	/*if (InKeyEvent.GetKey() == EKeys::Escape)
+	{
+	나중에 사용할수도?
+	}*/
+
+	return Super::NativeOnKeyDown(InGeometry, InKeyEvent);
 }
 
 void UShopWidget::SetAllItems(const TArray<UShopItemEntryData*>& EntryDataList, EShopCategoryTab Tab)
@@ -194,11 +222,13 @@ void UShopWidget::RefreshItemView()
 void UShopWidget::ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewInfoText)
 {
 	InfoWidget->ShowItemInfos(NewItemMesh, NewDescription, NewInfoText);
+	InfoWidget->GetItemMeshPanel()->SetMeshRotation(FRotator::ZeroRotator);
 }
 
 void UShopWidget::ShowUpgradeInfos(USkeletalMesh* NewUpgradeItemMesh, int32 CurrentUpgradeLevel, bool bIsMaxLevel, int32 CurrentUpgradeCost, const FString& ExtraInfoText)
 {
 	InfoWidget->ShowUpgradeInfos(NewUpgradeItemMesh, CurrentUpgradeLevel, bIsMaxLevel, CurrentUpgradeCost, ExtraInfoText);
+	InfoWidget->GetItemMeshPanel()->SetMeshRotation(FRotator::ZeroRotator);
 }
 
 void UShopWidget::OnCategoryTabClicked(EShopCategoryTab CategoryTab)

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
@@ -26,6 +26,9 @@ protected:
 
 	virtual void NativeConstruct() override;
 
+	virtual FReply NativeOnMouseMove(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
+	virtual FReply NativeOnKeyDown(const FGeometry& InGeometry, const FKeyEvent& InKeyEvent) override;
+
 #pragma region Methods
 
 public:
@@ -90,6 +93,7 @@ private:
 	EShopCategoryTab CurrentActivatedTab;
 
 	const int8 MAX_TAB_COUNT = 3;
+	const float MESH_ROTATION_SPEED = 0.5f;
 
 #pragma endregion
 


### PR DESCRIPTION

---

## 📝 작업 상세 내용
### 상점 아이템 메쉬 돌리기
- 아이템 클릭 후 메쉬 패널에서 드래그하면 좌 우로 회전.

### 기타
- 상점 열면 UIOnly 인풋 모드로 되도록 변경

---

