### PR TITLE
🐛 bugfix 상점 열고 이동 인풋이 유지되는 현상 수정

### DIFF
--- a/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
@@ -214,6 +214,7 @@ void AShop::OpenShop(AUnderwaterCharacter* Requester)
 	PC->SetInputMode(FInputModeUIOnly());
 	PC->SetShowMouseCursor(true);
 	bIsOpened = true;
+	PC->SetIgnoreMoveInput(true);
 }
 
 void AShop::CloseShop(AUnderwaterCharacter* Requester)
@@ -234,6 +235,7 @@ void AShop::CloseShop(AUnderwaterCharacter* Requester)
 	PC->SetInputMode(FInputModeGameOnly());
 	PC->SetShowMouseCursor(false);
 	bIsOpened = false;
+	PC->SetIgnoreMoveInput(false);
 }
 
 EBuyResult AShop::BuyItem(uint8 ItemId, uint8 Quantity, AUnderwaterCharacter* Buyer)


### PR DESCRIPTION

---

## 📝 작업 상세 내용
### 🐛 bugfix 상점 열고 이동 인풋이 유지되는 현상 수정
- 이동 인풋을 유지한 채로 상점을 열면 그 방향으로 계속 이동을 하던 현상 수정

---
