### PR TITLE
BugFix: BaseSpeed 속도 적용이 잘못되어 있는 오류 수정

### DIFF
--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
@@ -188,7 +188,7 @@ void AUnderwaterCharacter::ApplyUpgradeFactor(UUpgradeComponent* UpgradeComponen
 			    break;
 	    	case EUpgradeType::Speed:
 	    		// 최종 속도는 나중에 AdjustSpeed를 통해서 계산된다. 현재는 BaseSpeed만 조정하면 된다.
-	    		StatComponent->MoveSpeed = StatFactor;
+	    		StatComponent->MoveSpeed += StatFactor;
 	    		break;
 			case EUpgradeType::Light:
 	    		// @TODO Apply Light Component Upgrade 


### PR DESCRIPTION
---

## 📝 작업 상세 내용
<!-- 어떤 기능을 추가/수정했는지 상세히 기술해주세요 -->
- Upgrade 상태에서 BaseSpeed를 계산하는 방법이 잘못된 버그 수정
  - BaseSpeed = 400 + UpgradeFactor

## 현재 수정되지 않은 버그

- Host의 Player가 Upgrade 정보를 초기화하지 않는 오류
  - Upgrade Component 초기화 시점이 BeginPlay이고 Upgrade 정보 적용이 PossessedBy이기 때문에 Upgrade Component의 초기화 시점이 늦고 있습니다.

태스팅을 위해서 Upgrade Component  적용 부분만 수정하고 초기화 부분은 추후 수정하겠습니다.

---

## 📸 스크린샷 (선택)
<!-- UI, 이펙트, 레벨 디자인 등 시각적 작업 시 스크린샷 첨부 -->

---

## 🙋 리뷰어에게 요청사항
<!-- 리뷰 시 중점적으로 봐줬으면 하는 부분 -->

---
