### PR TITLE
상점 아이템 구매시 돈 차감, 상점 UI 갱신, 임시 Traansition 맵에 로딩 위젯 생성 및 기타

### DIFF
--- a/Content/_AbyssDiver/Blueprints/UI/InGameUI/WBP_LoadingScreen.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/InGameUI/WBP_LoadingScreen.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92bad8b430d1781b6c31e949fde10c68517628bb505042f94ad4be38877b449c
+size 25425

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestShop.uasset
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestShop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d074c575d079e4416b3828164b78ba38411eaa6d710f49c80d1fc494cf55d47f
-size 44495
+oid sha256:7d200921443ebb47b169c1ae93c1cfcd9e38bd55f32d6bea4b1e8b8f796fad8c
+size 44628

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/KY/TestTransitionMap.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/KY/TestTransitionMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0c57f9c8214ce7d93483eddd1c5f36161ce3d0d1bec7f1f2135b04d1fea6f3a
-size 8988
+oid sha256:9e62e5ac397d51941250b3f87d90fc9f11de1c6d937b9eaa734a93f264ff1257
+size 32145

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameState.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameState.cpp
@@ -41,6 +41,16 @@ void AADInGameState::PostInitializeComponents()
 void AADInGameState::BeginPlay()
 {
 	Super::BeginPlay();
+
+	if (HasAuthority() == false)
+	{
+		return;
+	}
+
+	TeamCreditsChangedDelegate.Broadcast(TeamCredits);
+	CurrentPhaseChangedDelegate.Broadcast(CurrentPhase);
+	CurrentPhaseGoalChangedDelegate.Broadcast(CurrentPhaseGoal);
+
 }
 
 void AADInGameState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
@@ -50,6 +60,15 @@ void AADInGameState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLi
 	DOREPLIFETIME(AADInGameState, SelectedLevelName);
 	DOREPLIFETIME(AADInGameState, TeamCredits);
 	DOREPLIFETIME(AADInGameState, CurrentPhase);
+}
+
+void AADInGameState::PostNetInit()
+{
+	Super::PostNetInit();
+
+	TeamCreditsChangedDelegate.Broadcast(TeamCredits);
+	CurrentPhaseChangedDelegate.Broadcast(CurrentPhase);
+	CurrentPhaseGoalChangedDelegate.Broadcast(CurrentPhaseGoal);
 }
 
 void AADInGameState::AddTeamCredit(int32 Credit)
@@ -83,17 +102,20 @@ void AADInGameState::OnRep_Money()
 {
 	// UI 업데이트
 	UE_LOG(LogTemp, Log, TEXT("TotalTeamCredit updated: %d"), TeamCredits);
+	TeamCreditsChangedDelegate.Broadcast(TeamCredits);
 }
 
 void AADInGameState::OnRep_Phase()
 {
 	// UI 업데이트
 	UE_LOG(LogTemp, Log, TEXT("Phase updated: %d/%d"), CurrentPhase, MaxPhase);
+	CurrentPhaseChangedDelegate.Broadcast(CurrentPhase);
 }
 
 void AADInGameState::OnRep_PhaseGoal()
 {
 	LOGVN(Error, TEXT("PhaseGoal updated: %d"), CurrentPhaseGoal);
+	CurrentPhaseGoalChangedDelegate.Broadcast(CurrentPhaseGoal);
 }
 
 FString AADInGameState::GetMapDisplayName() const

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.cpp
@@ -1,13 +1,18 @@
 ﻿#include "ShopElementInfoWidget.h"
 
+#include "AbyssDiverUnderWorld.h"
 #include "Shops/ShopWidgets/ShopItemMeshPanel.h"
+#include "Framework/ADInGameState.h"
 
 #include "Components/RichTextBlock.h"
 #include "Components/Button.h"
 #include "Components/Overlay.h"
+#include "Kismet/GameplayStatics.h"
 
-void UShopElementInfoWidget::NativeConstruct()
+void UShopElementInfoWidget::NativeOnInitialized()
 {
+	Super::NativeOnInitialized();
+
 	if (BuyButton->OnClicked.IsBound() == false)
 	{
 		BuyButton->OnClicked.AddDynamic(this, &UShopElementInfoWidget::OnBuyButtonClicked);
@@ -22,6 +27,16 @@ void UShopElementInfoWidget::NativeConstruct()
 	{
 		DecreaseButton->OnClicked.AddDynamic(this, &UShopElementInfoWidget::OnDecreaseButtonClicked);
 	}
+
+	AADInGameState* GS = Cast<AADInGameState>(UGameplayStatics::GetGameState(GetWorld()));
+	if (ensureMsgf(GS, TEXT("GS 캐스팅 실패, 게임 모드 확인 부탁.")) == false)
+	{
+		return;
+	}
+
+	GS->TeamCreditsChangedDelegate.AddUObject(this, &UShopElementInfoWidget::OnTeamCreditChanged);
+	bIsStackableItem = false;
+
 }
 
 void UShopElementInfoWidget::Init(USkeletalMeshComponent* NewItemMeshComp)
@@ -29,22 +44,38 @@ void UShopElementInfoWidget::Init(USkeletalMeshComponent* NewItemMeshComp)
 	ItemMeshPanel->Init(NewItemMeshComp);
 	CurrentQuantityNumber = 0;
 	ChangeCurrentQuantityNumber(0);
+
+	SetItemMeshActive(false);
+	SetDescriptionActive(false);
+	SetNameInfoTextActive(false);
+	SetBuyButtonActive(false);
+	SetUpgradeLevelInfoActive(false);
+	SetCostInfoActive(false);
+	SetQuantityOverlayActive(false);
+	SetRemainingMoneyAfterPurchaseTextActive(false);
 }
 
-void UShopElementInfoWidget::ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewNameInfoText)
+void UShopElementInfoWidget::ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewNameInfoText, int32 ItemCost, bool bIsStackable)
 {
 	SetItemMeshActive(true);
 	SetDescriptionActive(true);
 	SetNameInfoTextActive(true);
 	SetBuyButtonActive(true);
 	SetUpgradeLevelInfoActive(false);
-	SetCostInfoActive(false);
+	SetCostInfoActive(true);
+	SetQuantityOverlayActive(true); 
+	SetRemainingMoneyAfterPurchaseTextActive(true);
 
 	ChangeItemMesh(NewItemMesh);
 	ChangeItemDescription(NewDescription);
 	ChangeNameInfoText(NewNameInfoText);
+	ChangeCostInfo(ItemCost, false);
 	ChangeCurrentQuantityNumber(1);
-	SetQuantityOverlayActive(true);
+
+	CurrentCost = ItemCost;
+	bIsStackableItem = bIsStackable;
+
+	ChangeRemainingMoneyAfterPurchaseTextFromCost(ItemCost);
 }
 
 void UShopElementInfoWidget::ShowUpgradeInfos(USkeletalMesh* NewUpgradeItemMesh, int32 CurrentUpgradeLevel, bool bIsMaxLevel, int32 CurrentUpgradeCost, const FString& ExtraInfoText)
@@ -56,11 +87,15 @@ void UShopElementInfoWidget::ShowUpgradeInfos(USkeletalMesh* NewUpgradeItemMesh,
 	SetUpgradeLevelInfoActive(true);
 	SetCostInfoActive(true);
 	SetQuantityOverlayActive(false);
+	SetRemainingMoneyAfterPurchaseTextActive(true);
 
 	ChangeItemMesh(NewUpgradeItemMesh);
 	ChangeUpgradeLevelInfo(CurrentUpgradeLevel, bIsMaxLevel);
 	ChangeCostInfo(CurrentUpgradeCost, true);
 	ChangeCurrentQuantityNumber(1);
+
+	CurrentCost = CurrentUpgradeCost;
+	ChangeRemainingMoneyAfterPurchaseTextFromCost(CurrentUpgradeCost);
 }
 
 void UShopElementInfoWidget::ChangeItemDescription(const FString& NewDescription)
@@ -96,7 +131,7 @@ void UShopElementInfoWidget::ChangeUpgradeLevelInfo(int32 CurrentLevel, bool bIs
 	UpgradeLevelInfoText->SetText(FText::FromString(NewInfoText));
 }
 
-void UShopElementInfoWidget::ChangeCostInfo(int32 CurrentCost, bool bIsUpgradeCost)
+void UShopElementInfoWidget::ChangeCostInfo(int32 Cost, bool bIsUpgradeCost)
 {
 	FString NewInfoText = "";
 
@@ -109,7 +144,7 @@ void UShopElementInfoWidget::ChangeCostInfo(int32 CurrentCost, bool bIsUpgradeCo
 		NewInfoText = TEXT("<S>비용 ");
 	}
 
-	NewInfoText += FString::FromInt(CurrentCost);
+	NewInfoText += FString::FromInt(Cost);
 	NewInfoText += TEXT("Cr</>");
 	
 	CostInfoText->SetText(FText::FromString(NewInfoText));
@@ -117,12 +152,48 @@ void UShopElementInfoWidget::ChangeCostInfo(int32 CurrentCost, bool bIsUpgradeCo
 
 void UShopElementInfoWidget::ChangeCurrentQuantityNumber(int32 NewNumber)
 {
-	CurrentQuantityNumber = FMath::Clamp(NewNumber, 1, MAX_ITEM_COUNT);
+	AADInGameState* GS = Cast<AADInGameState>(UGameplayStatics::GetGameState(GetWorld()));
+	if (GS == nullptr)
+	{
+		LOGV(Warning, TEXT("GS == nullptr"));
+		return;
+	}
+
+	if (bIsStackableItem)
+	{
+		int32 MaxCount = (CurrentCost == 0) ? MAX_ITEM_COUNT : FMath::Min(MAX_ITEM_COUNT, GS->GetTotalTeamCredit() / CurrentCost * NewNumber);
+		if (MaxCount == 0)
+		{
+			NewNumber = 0;
+		}
+		else
+		{
+			NewNumber = FMath::Clamp(NewNumber, 1, MaxCount);
+		}
+	}
+	else
+	{
+		NewNumber = (GS->GetTotalTeamCredit() >= CurrentCost) ? 1 : 0;
+	}
+
+	CurrentQuantityNumber = NewNumber;
 	CurrentQuantityNumberText->SetText(FText::FromString(FString::FromInt(CurrentQuantityNumber)));
+}
+
+void UShopElementInfoWidget::ChangeRemainingMoneyAfterPurchaseTextFromCost(int32 Cost)
+{
+	AADInGameState* GS = CastChecked<AADInGameState>(UGameplayStatics::GetGameState(GetWorld()));
+	int32 RemainingMoney = GS->GetTotalTeamCredit() - Cost * CurrentQuantityNumber;
+	ChangeRemainingMoneyAfterPurchaseText(RemainingMoney);
 }
 
 void UShopElementInfoWidget::ChangeRemainingMoneyAfterPurchaseText(int32 MoneyAmount)
 {
+	FString NewText = TEXT("<S>구매 후 남는 잔액 ");
+	NewText += FString::FromInt(MoneyAmount);
+	NewText += TEXT("Cr</>");
+
+	RemainingMoneyAfterPurchaseText->SetText(FText::FromString(NewText));
 }
 
 void UShopElementInfoWidget::SetDescriptionActive(bool bShouldActivate)
@@ -202,6 +273,18 @@ void UShopElementInfoWidget::SetQuantityOverlayActive(bool bShouldActivate)
 	}
 }
 
+void UShopElementInfoWidget::SetRemainingMoneyAfterPurchaseTextActive(bool bShouldActivate)
+{
+	if (bShouldActivate)
+	{
+		RemainingMoneyAfterPurchaseText->SetVisibility(ESlateVisibility::SelfHitTestInvisible);
+	}
+	else
+	{
+		RemainingMoneyAfterPurchaseText->SetVisibility(ESlateVisibility::Hidden);
+	}
+}
+
 void UShopElementInfoWidget::OnBuyButtonClicked()
 {
 	OnBuyButtonClickedDelegate.Broadcast(CurrentQuantityNumber);
@@ -210,11 +293,18 @@ void UShopElementInfoWidget::OnBuyButtonClicked()
 void UShopElementInfoWidget::OnIncreaseButtonClicked()
 {
 	ChangeCurrentQuantityNumber(CurrentQuantityNumber + 1);
+	ChangeRemainingMoneyAfterPurchaseTextFromCost(CurrentCost);
 }
 
 void UShopElementInfoWidget::OnDecreaseButtonClicked()
 {
 	ChangeCurrentQuantityNumber(CurrentQuantityNumber - 1);
+	ChangeRemainingMoneyAfterPurchaseTextFromCost(CurrentCost);
+}
+
+void UShopElementInfoWidget::OnTeamCreditChanged(int32 ChangedValue)
+{
+	ChangeRemainingMoneyAfterPurchaseTextFromCost(CurrentCost);
 }
 
 UShopItemMeshPanel* UShopElementInfoWidget::GetItemMeshPanel() const

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.h
@@ -21,7 +21,7 @@ class ABYSSDIVERUNDERWORLD_API UShopElementInfoWidget : public UUserWidget
 
 protected:
 
-	virtual void NativeConstruct() override;
+	virtual void NativeOnInitialized() override;
 	
 #pragma region Methods, Delegates
 
@@ -29,7 +29,7 @@ public:
 
 	void Init(USkeletalMeshComponent* NewItemMeshComp);
 
-	void ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewInfoText);
+	void ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewNameInfoText, int32 ItemCost, bool bIsStackable);
 	void ShowUpgradeInfos(USkeletalMesh* NewUpgradeItemMesh, int32 CurrentUpgradeLevel, bool bIsMaxLevel, int32 CurrentUpgradeCost, const FString& ExtraInfoText);
 
 	void ChangeItemDescription(const FString& NewDescription);
@@ -37,9 +37,11 @@ public:
 	void ChangeItemMesh(USkeletalMesh* NewMesh);
 
 	void ChangeUpgradeLevelInfo(int32 CurrentLevel, bool bIsMaxLevel);
-	void ChangeCostInfo(int32 CurrentCost, bool bIsUpgradeCost);
+	void ChangeCostInfo(int32 Cost, bool bIsUpgradeCost);
 
 	void ChangeCurrentQuantityNumber(int32 NewNumber);
+
+	void ChangeRemainingMoneyAfterPurchaseTextFromCost(int32 Cost);
 	void ChangeRemainingMoneyAfterPurchaseText(int32 MoneyAmount);
 
 	void SetDescriptionActive(bool bShouldActivate);
@@ -51,6 +53,8 @@ public:
 	void SetCostInfoActive(bool bShouldActivate);
 
 	void SetQuantityOverlayActive(bool bShouldActivate);
+
+	void SetRemainingMoneyAfterPurchaseTextActive(bool bShouldActivate);
 
 	FOnBuyButtonClickedDelegate OnBuyButtonClickedDelegate;
 
@@ -64,6 +68,8 @@ private:
 
 	UFUNCTION()
 	void OnDecreaseButtonClicked();
+
+	void OnTeamCreditChanged(int32 ChangedValue);
 
 #pragma endregion
 
@@ -107,6 +113,9 @@ protected:
 private:
 
 	int32 CurrentQuantityNumber = 0;
+	int32 CurrentCost = INT_MAX;
+
+	uint8 bIsStackableItem : 1;
 
 	const int32 MAX_ITEM_COUNT = 99;
 
@@ -115,6 +124,7 @@ private:
 #pragma region Getter / Setter
 
 public:
+
 	UShopItemMeshPanel* GetItemMeshPanel() const;
 
 #pragma endregion

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
@@ -16,11 +16,9 @@
 #include "Components/RichTextBlock.h"
 #include "Kismet/GameplayStatics.h"
 
-void UShopWidget::NativeConstruct()
+void UShopWidget::NativeOnInitialized()
 {
-	Super::NativeConstruct();
-
-	CurrentActivatedTab = EShopCategoryTab::Consumable;
+	Super::NativeOnInitialized();
 
 	ConsumableTab->OnShopCategoryTabClickedDelegate.AddUObject(this, &UShopWidget::OnCategoryTabClicked);
 	EquipmentTab->OnShopCategoryTabClickedDelegate.AddUObject(this, &UShopWidget::OnCategoryTabClicked);
@@ -30,6 +28,13 @@ void UShopWidget::NativeConstruct()
 	{
 		CloseButton->OnClicked.AddDynamic(this, &UShopWidget::OnCloseButtonClicked);
 	}
+}
+
+void UShopWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	CurrentActivatedTab = EShopCategoryTab::Equipment;
 }
 
 FReply UShopWidget::NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
@@ -228,9 +233,9 @@ void UShopWidget::RefreshItemView()
 	}
 }
 
-void UShopWidget::ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewInfoText)
+void UShopWidget::ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewNameInfoText, int32 ItemCost, bool bIsStackable)
 {
-	InfoWidget->ShowItemInfos(NewItemMesh, NewDescription, NewInfoText);
+	InfoWidget->ShowItemInfos(NewItemMesh, NewDescription, NewNameInfoText, ItemCost, bIsStackable);
 	InfoWidget->GetItemMeshPanel()->SetMeshRotation(FRotator::ZeroRotator);
 }
 

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
@@ -24,6 +24,7 @@ class ABYSSDIVERUNDERWORLD_API UShopWidget : public UUserWidget
 
 protected:
 
+	virtual void NativeOnInitialized() override;
 	virtual void NativeConstruct() override;
 
 	virtual FReply NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
@@ -42,7 +43,7 @@ public:
 	void ShowItemViewForTab(EShopCategoryTab TabType);
 	void RefreshItemView();
 
-	void ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewInfoText);
+	void ShowItemInfos(USkeletalMesh* NewItemMesh, const FString& NewDescription, const FString& NewNameInfoText, int32 ItemCost, bool bIsStackable);
 	void ShowUpgradeInfos(USkeletalMesh* NewUpgradeItemMesh, int32 CurrentUpgradeLevel, bool bIsMaxLevel, int32 CurrentUpgradeCost, const FString& ExtraInfoText);
 
 	void SetTeamMoneyText(int32 NewTeamMoney);


### PR DESCRIPTION

## 📝 작업 상세 내용

### 상점
- 초기 상점 탭은 장비창으로 고정
- 장비는 1개씩 구매하도록 설정
- 클라이언트에서 미리 돈 체크 후 구매 시도

### 기타
- ADInGameState : UI 갱신용 델리게이트 선언
- TeamCreditsChangedDelegate, CurrentPhaseChangedDelegate, CurrentPhaseGoalChangedDelegate
- 현재 패키징시 상점 버그 있음
- 특정 플레이어 상점 UI 갱신 안 됨, 이후 튕김
- 여러개 구매해도 1개 분량의 돈 감소
- 상점 UI 개수 표시 버그 - 최대량이 소지금보다 더 많게 설정 가능, 0개 가능

---
