### PR TITLE
🐛 bugfix 상점 버그 해결 및 기타

### DIFF
--- a/Source/AbyssDiverUnderWorld/Shops/Shop.h
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.h
@@ -8,6 +8,10 @@
 
 #include "Shop.generated.h"
 
+#define LOGS(Verbosity, Format, ...) UE_LOG(ShopLog, Verbosity, TEXT("%s(%s) %s"), ANSI_TO_TCHAR(__FUNCTION__), *FString::FromInt(__LINE__), *FString::Printf(Format, ##__VA_ARGS__));
+
+DECLARE_LOG_CATEGORY_EXTERN(ShopLog, Log, All);
+
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnShopItemListChangedDelegate, const FShopItemListChangeInfo&);
 
 #pragma region Enums

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.h
@@ -116,6 +116,7 @@ private:
 	int32 CurrentCost = INT_MAX;
 
 	uint8 bIsStackableItem : 1;
+	uint8 bIsShowingUpgradeView : 1;
 
 	const int32 MAX_ITEM_COUNT = 99;
 

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopTileView.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopTileView.cpp
@@ -1,8 +1,21 @@
 #include "Shops/ShopWidgets/ShopTileView.h"
 
 #include "Shops/ShopItemEntryData.h"
+#include "AbyssDiverUnderWorld.h"
 
 void UShopTileView::SetAllElements(const TArray<UShopItemEntryData*>& Elements)
 {
+	FString DebugText = TEXT("Tile Initialized : (");
+
+	for (auto& E : Elements)
+	{
+		DebugText += FString::FromInt(E->GetSlotIndex());
+		DebugText += TEXT(", ");
+	}
+
+	DebugText = DebugText.LeftChop(2);
+	DebugText += TEXT(")");
+
+	LOGV(Warning, TEXT("%s"), *DebugText);
 	SetListItems(Elements);
 }


### PR DESCRIPTION


---

## 📝 작업 상세 내용
### 상점 버그 해결
- 아이템 다량 구매해도 1개분량 만큼만 돈이 차감되는 현상 수정
- 아이템 수량 조절 버그 수정
- 업그레이드 탭 누르면 크래시 나는 버그 수정

### 기타
- 상점용 로그 카테고리 선언, 상점 버그 디버깅용
- 아직 클라이언트에서 상점 버그 일어나는 조건도 모름..

---
