### PR TITLE
🐛 bugfix 상점 버그 해결 및 기타

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -96,7 +96,7 @@ bSkipMovies=False
 +IniSectionDenylist=/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings
 +MapsToCook=(FilePath="/Game/_AbyssDiver/Maps/Prototypes_Test/KY/MainLevel")
 +MapsToCook=(FilePath="/Game/_AbyssDiver/Maps/Prototypes_Test/KY/Lobby_Test")
-+MapsToCook=(FilePath="/Game/_AbyssDiver/Maps/Prototypes_Test/KY/Shallow_Test")
++MapsToCook=(FilePath="/Game/_AbyssDiver/Maps/Prototypes_Test/KY/Shallow")
 +DirectoriesToAlwaysCook=(Path="/NNEDenoiser")
 bRetainStagedDirectory=False
 CustomStageCopyHandler=

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/KY/Shallow.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/KY/Shallow.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb72a49c6a1c4ccbe4a5246fee76f0a9ed5dd38da860d21b1ad4e06ba70b7087
-size 74820434
+oid sha256:f841b141c6f2123428b58c8077b4bfc53655da18d1c7c7e8c6110496692137f2
+size 74821778

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.cpp
@@ -152,10 +152,22 @@ void AADInGameMode::GetOre()
 		99,
 		1,
 		1,
-		1000,
+		10000,
 		EItemType::Exchangable,
 		nullptr
 	);
 
 	PS->GetInventory()->AddInventoryItem(ItemData);
+}
+
+void AADInGameMode::GetMoney()
+{
+	AADInGameState* GS = GetGameState<AADInGameState>();
+	if (GS == nullptr)
+	{
+		LOGVN(Error, TEXT("Cheat Failed : GS == nullptr"));
+		return;
+	}
+
+	GS->SetTotalTeamCredit(GS->GetTotalTeamCredit() + 10000);
 }

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.h
@@ -33,6 +33,9 @@ private:
 
 	UFUNCTION(Exec, Category = "Cheat")
 	void GetOre();
+	
+	UFUNCTION(Exec, Category = "Cheat")
+	void GetMoney();
 
 #pragma endregion
 

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.cpp
@@ -30,8 +30,6 @@ void UShopElementInfoWidget::NativeOnInitialized()
 		DecreaseButton->OnClicked.AddDynamic(this, &UShopElementInfoWidget::OnDecreaseButtonClicked);
 	}
 
-
-	
 	bIsStackableItem = false;
 	bIsShowingUpgradeView = false;
 }

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemMeshPanel.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemMeshPanel.cpp
@@ -55,6 +55,11 @@ void UShopItemMeshPanel::SetItemMeshActive(bool bShouldActivate)
 
 void UShopItemMeshPanel::AddMeshRotationYaw(float Yaw)
 {
+	if (Yaw == 0.0f)
+	{
+		return;
+	}
+
 	FRotator NewRotator = ItemMeshComponent->GetComponentRotation();
 	NewRotator.Yaw += Yaw;
 	SetMeshRotation(NewRotator);
@@ -62,7 +67,7 @@ void UShopItemMeshPanel::AddMeshRotationYaw(float Yaw)
 
 void UShopItemMeshPanel::SetMeshRotation(const FRotator& NewRotator)
 {
-	ItemMeshComponent->SetRelativeRotation(NewRotator, true);
+	ItemMeshComponent->SetWorldRotation(NewRotator, true);
 }
 
 bool UShopItemMeshPanel::GetMouseDown() const

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.cpp
@@ -22,7 +22,6 @@ void UShopItemSlotWidget::NativeOnListItemObjectSet(UObject* ListItemObject)
     SlotIndex = EntryData->GetSlotIndex();
 
     EntryData->OnEntryUpdatedFromDataDelegate.Broadcast(this);
-    LOGV(Log, TEXT("%s - EntryUpdated, Index : %d"), *GetName(), SlotIndex);
 }
 
 FReply UShopItemSlotWidget::NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
@@ -28,11 +28,6 @@ void UShopWidget::NativeOnInitialized()
 	{
 		CloseButton->OnClicked.AddDynamic(this, &UShopWidget::OnCloseButtonClicked);
 	}
-}
-
-void UShopWidget::NativeConstruct()
-{
-	Super::NativeConstruct();
 
 	CurrentActivatedTab = EShopCategoryTab::Equipment;
 }
@@ -241,7 +236,6 @@ void UShopWidget::ShowItemInfos(int32 ItemId)
 void UShopWidget::ShowUpgradeInfos(USkeletalMesh* NewUpgradeItemMesh, int32 CurrentUpgradeLevel, bool bIsMaxLevel, int32 CurrentUpgradeCost, const FString& ExtraInfoText)
 {
 	InfoWidget->ShowUpgradeInfos(NewUpgradeItemMesh, CurrentUpgradeLevel, bIsMaxLevel, CurrentUpgradeCost, ExtraInfoText);
-	InfoWidget->GetItemMeshPanel()->SetMeshRotation(FRotator::ZeroRotator);
 }
 
 void UShopWidget::SetTeamMoneyText(int32 NewTeamMoney)

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
@@ -21,11 +21,9 @@ class ABYSSDIVERUNDERWORLD_API UShopWidget : public UUserWidget
 {
 	GENERATED_BODY()
 
-
 protected:
 
 	virtual void NativeOnInitialized() override;
-	virtual void NativeConstruct() override;
 
 	virtual FReply NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
 	virtual FReply NativeOnMouseMove(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;


### PR DESCRIPTION


---

## 📝 작업 상세 내용
### 상점 버그 해결
- 아이템 메쉬 회전이 한쪽방향으로만 일어나는 현상 수정
- 아이템 목록 뷰 위젯이 데이터와 다르게 항상 장비창으로 뜨는 현상 수정

### 기타
- 공통 자금 상승 치트 추가 GetMoney 함수
- GetOre 치트 10000원짜리 광물로 변경
- 패키징에 Shallow맵 추가

---
