### PR TITLE
상점 아이템 프리뷰 메쉬 최적화

### DIFF
--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestShop.uasset
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestShop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9bc35b6d0cae16ce15a5a3cb208eb22bcf9d6a380d1bf312b668004204f15172
-size 44432
+oid sha256:aa0dfcfbc91d235a885c1e93ee2d06021d7de62771638389dd3f57707d3eb223
+size 32740

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f462c69c5868cc55dc6c1fd0856b12aa6d4d15cc4c41b6f7da7d6e89bb44bf9b
-size 105382
+oid sha256:28eff8c2fe2b20a1a04b0462ede8056df3f34e83bc1e6ee069b5966dde216f42
+size 108346

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameState.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameState.cpp
@@ -95,7 +95,7 @@ void AADInGameState::SendDataToGameInstance()
 		ADGameInstance->TeamCredits = TeamCredits;
 	}
 
-	LOGVN(Error, TEXT("SelectedLevelName: %s / TeamCredits: %d"), SelectedLevelName, TeamCredits);
+	LOGVN(Error, TEXT("SelectedLevelName: %d / TeamCredits: %d"), SelectedLevelName, TeamCredits);
 }
 
 void AADInGameState::OnRep_Money()

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
@@ -23,6 +23,7 @@
 
 #include "Net/UnrealNetwork.h"
 #include "Kismet/GameplayStatics.h"
+#include "Components/SceneCaptureComponent2D.h"
 
 DEFINE_LOG_CATEGORY(ShopLog);
 
@@ -149,6 +150,55 @@ AShop::AShop()
 	ItemMeshComponent->SetVisibleInSceneCaptureOnly(true);
 	ItemMeshComponent->SetIsReplicated(false);
 	ItemMeshComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	// 설정을 좀 더 건드려야 함. 
+	ItemMeshCaptureComp = CreateDefaultSubobject<USceneCaptureComponent2D>(TEXT("ItemMeshCapureComp"));
+	ItemMeshCaptureComp->SetupAttachment(RootComponent);
+	ItemMeshCaptureComp->ShowFlags.AntiAliasing = false;
+	ItemMeshCaptureComp->ShowFlags.Atmosphere = false;
+	ItemMeshCaptureComp->ShowFlags.BSP = false;
+	ItemMeshCaptureComp->ShowFlags.Cloud = false;
+	ItemMeshCaptureComp->ShowFlags.Decals = false;
+	ItemMeshCaptureComp->ShowFlags.Fog = false;
+	ItemMeshCaptureComp->ShowFlags.Landscape = false;
+	ItemMeshCaptureComp->ShowFlags.Particles = false;
+	ItemMeshCaptureComp->ShowFlags.SkeletalMeshes = true;
+	ItemMeshCaptureComp->ShowFlags.StaticMeshes = false;
+	ItemMeshCaptureComp->ShowFlags.Translucency = false;
+
+	ItemMeshCaptureComp->ShowFlags.DisableAdvancedFeatures();
+
+	ItemMeshCaptureComp->ShowFlags.Bloom = false;
+	ItemMeshCaptureComp->ShowFlags.EyeAdaptation = false;
+	ItemMeshCaptureComp->ShowFlags.LocalExposure = false;
+	ItemMeshCaptureComp->ShowFlags.MotionBlur = false;
+	ItemMeshCaptureComp->ShowFlags.PostProcessMaterial = false;
+	ItemMeshCaptureComp->ShowFlags.ToneCurve = false;
+	ItemMeshCaptureComp->ShowFlags.Tonemapper = false;
+
+	ItemMeshCaptureComp->ShowFlags.SkyLighting = false;
+
+	ItemMeshCaptureComp->ShowFlags.AmbientOcclusion = false;
+	ItemMeshCaptureComp->ShowFlags.DynamicShadows = false;
+
+	ItemMeshCaptureComp->ShowFlags.AmbientCubemap = false;
+	ItemMeshCaptureComp->ShowFlags.DistanceFieldAO = false;
+	ItemMeshCaptureComp->ShowFlags.LightFunctions = false;
+	ItemMeshCaptureComp->ShowFlags.LightShafts = false;
+	ItemMeshCaptureComp->ShowFlags.ReflectionEnvironment = false;
+	ItemMeshCaptureComp->ShowFlags.ScreenSpaceReflections = false;
+	ItemMeshCaptureComp->ShowFlags.TexturedLightProfiles = false;
+	ItemMeshCaptureComp->ShowFlags.VolumetricFog = false;
+
+	ItemMeshCaptureComp->ShowFlags.NaniteMeshes = true;
+
+	//ItemMeshCaptureComp->ShowFlags.Game = false;
+	//ItemMeshCaptureComp->ShowFlags.Lighting = false;
+	//ItemMeshCaptureComp->ShowFlags.PathTracing = false;
+	//ItemMeshCaptureComp->ShowFlags.PostProcessing = false;
+
+	ItemMeshCaptureComp->bCaptureEveryFrame = false;
+
+	ItemMeshCaptureComp->SetRelativeLocation(FVector(200, 0, 0));
 
 	InteractableComp = CreateDefaultSubobject<UADInteractableComponent>(TEXT("InteractableComp"));
 
@@ -242,6 +292,7 @@ void AShop::OpenShop(AUnderwaterCharacter* Requester)
 	PC->SetShowMouseCursor(true);
 	bIsOpened = true;
 	PC->SetIgnoreMoveInput(true);
+	ItemMeshCaptureComp->bCaptureEveryFrame = true;
 }
 
 void AShop::CloseShop(AUnderwaterCharacter* Requester)
@@ -263,6 +314,8 @@ void AShop::CloseShop(AUnderwaterCharacter* Requester)
 	PC->SetShowMouseCursor(false);
 	bIsOpened = false;
 	PC->SetIgnoreMoveInput(false);
+
+	ItemMeshCaptureComp->bCaptureEveryFrame = false;
 }
 
 EBuyResult AShop::BuyItem(uint8 ItemId, uint8 Quantity, AUnderwaterCharacter* Buyer)
@@ -607,6 +660,9 @@ void AShop::InitShopWidget()
 
 	InfoWidget->Init(ItemMeshComponent);
 	InfoWidget->OnBuyButtonClickedDelegate.AddUObject(this, &AShop::OnBuyButtonClicked);
+
+	ItemMeshCaptureComp->ShowOnlyActorComponents(this);
+	ensureMsgf(ItemMeshCaptureComp->TextureTarget, TEXT("상점에 있는 ItemMeshCaptureComp의 TextureTarget이 지정이 되어있지 않습니다"));
 }
 
 void AShop::InitData()

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.h
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.h
@@ -49,6 +49,7 @@ class AShop;
 class UShopWidget;
 class UShopItemEntryData;
 class AUnderwaterCharacter;
+class USceneCaptureComponent2D;
 
 struct FFADItemDataRow;
 struct FShopItemIdList;
@@ -218,6 +219,9 @@ protected:
 
 	UPROPERTY(VisibleAnywhere, Category = "Shop")
 	TObjectPtr<USkeletalMeshComponent> ItemMeshComponent;
+
+	UPROPERTY(VisibleAnywhere, Category = "Shop")
+	TObjectPtr<USceneCaptureComponent2D> ItemMeshCaptureComp;
 
 	UPROPERTY(EditDefaultsOnly, Category = "Shop");
 	TArray<uint8> DefaultConsumableItemIdList; // 블루프린트 노출용


### PR DESCRIPTION


---

## 📝 작업 상세 내용
### 상점 아이템 프리뷰 메쉬 최적화
- Render Target으로 그리는 메쉬가 생각보다 너무 많은 성능저하를 일으켜서 최적화
- 상점을 열었을 때만 Render Target 활성화로 변경
- 우선 메쉬에 적용되는 각종 효과는 제거, 후에 효과 적용 예정

---
