### PR TITLE
✨ update 레이더 방향 고정 기능 추가

### DIFF
--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestRadarReturnActor.uasset
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestRadarReturnActor.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f66277db6262a267b432760f952d4fcd73b394395235979fd3fc78c89faf452d
-size 31793
+oid sha256:5c22c20fc12bfa571b1802b8deb4ef3cd4e453ba973141e44b70e52c6b3763b3
+size 32739

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28eff8c2fe2b20a1a04b0462ede8056df3f34e83bc1e6ee069b5966dde216f42
-size 108346
+oid sha256:1bd2c0a683e60e723892cb762e87ca05ed61e8d6711b7e6f08c9f6f61c00d387
+size 104479

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/Radar.h
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/Radar.h
@@ -22,7 +22,8 @@ enum class EGridRotationOption : uint8
 	NoGridRotation,
 	MaintainLocalRotation,
 	ZRotationOnly,
-	ZMatchesWorld
+	ZMatchesWorld,
+	IgnoreYawRotation,
 };
 
 USTRUCT(BlueprintType)
@@ -114,6 +115,7 @@ protected:
 #pragma region Methods
 public:
 
+	UFUNCTION(BlueprintCallable, Category = "Radar")
 	void UpdateRadarSourceComponent(USceneComponent* NewRadarSourceLocation, USceneComponent* NewRadarSourceRotation);
 	void AddReturn(URadarReturnComponent* RadarReturn, EFriendOrFoe FriendOrFoe);
 	void RemoveReturn(URadarReturnComponent* RadarReturn, int32 InIndex);
@@ -331,6 +333,8 @@ public:
 
 	const FName& GetRadarTag() const;
 	void SetRadarTag(const FName& NewTag);
+
+	void SetGridRotationOption(EGridRotationOption Option);
 
 #pragma endregion
 


### PR DESCRIPTION


---

## 📝 작업 상세 내용
- Yaw 회전에 상관없이 같은 위치에 RaderReturn이 뜨도록 하는 기능
- Rader 클래스의 SetGridRotationOption을 통해 EGridRotationOption::IgnoreYawRotation로 설정하여 사용 가능

---
