### PR TITLE
✨ update 상점 전용 라이트 추가 및 기타

### DIFF
--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestShop.uasset
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_TestShop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa0dfcfbc91d235a885c1e93ee2d06021d7de62771638389dd3f57707d3eb223
-size 32740
+oid sha256:c3c769cdb1a8dab947623451d7ecb162b69b07ed3ff556bb68ab3fc628f0e4b8
+size 33617

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1bd2c0a683e60e723892cb762e87ca05ed61e8d6711b7e6f08c9f6f61c00d387
-size 104479
+oid sha256:72f7737bdd3488d98763784c074be0cf59a068d3fba0bf98e061980c79fdaa01
+size 105153

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
@@ -24,6 +24,7 @@
 #include "Net/UnrealNetwork.h"
 #include "Kismet/GameplayStatics.h"
 #include "Components/SceneCaptureComponent2D.h"
+#include "Components/PointLightComponent.h"
 
 DEFINE_LOG_CATEGORY(ShopLog);
 
@@ -144,16 +145,23 @@ AShop::AShop()
 
 	ShopMeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("ShopMesh"));
 	SetRootComponent(ShopMeshComponent);
+	ShopMeshComponent->SetMobility(EComponentMobility::Static);
 
 	ItemMeshComponent = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("ItemMesh"));
 	ItemMeshComponent->SetupAttachment(RootComponent);
 	ItemMeshComponent->SetVisibleInSceneCaptureOnly(true);
 	ItemMeshComponent->SetIsReplicated(false);
 	ItemMeshComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+	// 라이팅 채널 2번만 사용. 상점 아이템 메쉬용
+	ItemMeshComponent->LightingChannels.bChannel0 = false;
+	ItemMeshComponent->LightingChannels.bChannel1 = false;
+	ItemMeshComponent->LightingChannels.bChannel2 = true;
+
 	// 설정을 좀 더 건드려야 함. 
 	ItemMeshCaptureComp = CreateDefaultSubobject<USceneCaptureComponent2D>(TEXT("ItemMeshCapureComp"));
 	ItemMeshCaptureComp->SetupAttachment(RootComponent);
-	ItemMeshCaptureComp->ShowFlags.AntiAliasing = false;
+	ItemMeshCaptureComp->ShowFlags.AntiAliasing = true;
 	ItemMeshCaptureComp->ShowFlags.Atmosphere = false;
 	ItemMeshCaptureComp->ShowFlags.BSP = false;
 	ItemMeshCaptureComp->ShowFlags.Cloud = false;
@@ -165,15 +173,20 @@ AShop::AShop()
 	ItemMeshCaptureComp->ShowFlags.StaticMeshes = false;
 	ItemMeshCaptureComp->ShowFlags.Translucency = false;
 
-	ItemMeshCaptureComp->ShowFlags.DisableAdvancedFeatures();
+	ItemMeshCaptureComp->ShowFlags.InstancedFoliage = false;
+	ItemMeshCaptureComp->ShowFlags.InstancedGrass = false;
+	ItemMeshCaptureComp->ShowFlags.InstancedStaticMeshes = false;
+	ItemMeshCaptureComp->ShowFlags.Paper2DSprites = false;
+	ItemMeshCaptureComp->ShowFlags.TextRender = false;
+	ItemMeshCaptureComp->ShowFlags.TemporalAA = true;
 
-	ItemMeshCaptureComp->ShowFlags.Bloom = false;
+	ItemMeshCaptureComp->ShowFlags.Bloom = true;
 	ItemMeshCaptureComp->ShowFlags.EyeAdaptation = false;
 	ItemMeshCaptureComp->ShowFlags.LocalExposure = false;
 	ItemMeshCaptureComp->ShowFlags.MotionBlur = false;
-	ItemMeshCaptureComp->ShowFlags.PostProcessMaterial = false;
-	ItemMeshCaptureComp->ShowFlags.ToneCurve = false;
-	ItemMeshCaptureComp->ShowFlags.Tonemapper = false;
+	ItemMeshCaptureComp->ShowFlags.PostProcessMaterial = true;
+	ItemMeshCaptureComp->ShowFlags.ToneCurve = true;
+	ItemMeshCaptureComp->ShowFlags.Tonemapper = true;
 
 	ItemMeshCaptureComp->ShowFlags.SkyLighting = false;
 
@@ -191,14 +204,20 @@ AShop::AShop()
 
 	ItemMeshCaptureComp->ShowFlags.NaniteMeshes = true;
 
-	//ItemMeshCaptureComp->ShowFlags.Game = false;
-	//ItemMeshCaptureComp->ShowFlags.Lighting = false;
-	//ItemMeshCaptureComp->ShowFlags.PathTracing = false;
-	//ItemMeshCaptureComp->ShowFlags.PostProcessing = false;
-
 	ItemMeshCaptureComp->bCaptureEveryFrame = false;
 
 	ItemMeshCaptureComp->SetRelativeLocation(FVector(200, 0, 0));
+
+	LightComp = CreateDefaultSubobject<UPointLightComponent>(TEXT("LightComp"));
+	LightComp->SetupAttachment(ItemMeshCaptureComp);
+
+	// 라이팅 채널 2번만 사용. 상점 아이템 메쉬용
+	LightComp->LightingChannels.bChannel0 = false;
+	LightComp->LightingChannels.bChannel1 = false;
+	LightComp->LightingChannels.bChannel2 = true;
+
+	LightComp->SetMobility(EComponentMobility::Static);
+	LightComp->SetRelativeLocation(FVector(0, 0, 100));
 
 	InteractableComp = CreateDefaultSubobject<UADInteractableComponent>(TEXT("InteractableComp"));
 

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.h
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.h
@@ -50,6 +50,7 @@ class UShopWidget;
 class UShopItemEntryData;
 class AUnderwaterCharacter;
 class USceneCaptureComponent2D;
+class UPointLightComponent;
 
 struct FFADItemDataRow;
 struct FShopItemIdList;
@@ -222,6 +223,9 @@ protected:
 
 	UPROPERTY(VisibleAnywhere, Category = "Shop")
 	TObjectPtr<USceneCaptureComponent2D> ItemMeshCaptureComp;
+
+	UPROPERTY(VisibleAnywhere, Category = "Shop")
+	TObjectPtr<UPointLightComponent> LightComp;
 
 	UPROPERTY(EditDefaultsOnly, Category = "Shop");
 	TArray<uint8> DefaultConsumableItemIdList; // 블루프린트 노출용

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
@@ -20,16 +20,27 @@ void UShopWidget::NativeOnInitialized()
 {
 	Super::NativeOnInitialized();
 
+	CurrentActivatedTab = EShopCategoryTab::Equipment;
+}
+
+void UShopWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
 	ConsumableTab->OnShopCategoryTabClickedDelegate.AddUObject(this, &UShopWidget::OnCategoryTabClicked);
 	EquipmentTab->OnShopCategoryTabClickedDelegate.AddUObject(this, &UShopWidget::OnCategoryTabClicked);
 	UpgradeTab->OnShopCategoryTabClickedDelegate.AddUObject(this, &UShopWidget::OnCategoryTabClicked);
+	CloseButton->OnClicked.AddDynamic(this, &UShopWidget::OnCloseButtonClicked);
+}
 
-	if (CloseButton->OnClicked.IsBound() == false)
-	{
-		CloseButton->OnClicked.AddDynamic(this, &UShopWidget::OnCloseButtonClicked);
-	}
+void UShopWidget::NativeDestruct()
+{
+	Super::NativeDestruct();
 
-	CurrentActivatedTab = EShopCategoryTab::Equipment;
+	ConsumableTab->OnShopCategoryTabClickedDelegate.RemoveAll(this);
+	EquipmentTab->OnShopCategoryTabClickedDelegate.RemoveAll(this);
+	UpgradeTab->OnShopCategoryTabClickedDelegate.RemoveAll(this);
+	CloseButton->OnClicked.RemoveAll(this);
 }
 
 FReply UShopWidget::NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.h
@@ -24,6 +24,8 @@ class ABYSSDIVERUNDERWORLD_API UShopWidget : public UUserWidget
 protected:
 
 	virtual void NativeOnInitialized() override;
+	virtual void NativeConstruct() override;
+	virtual void NativeDestruct() override;
 
 	virtual FReply NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
 	virtual FReply NativeOnMouseMove(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;


### PR DESCRIPTION

---

## 📝 작업 상세 내용
### 상점 전용 라이트 추가
- 상점의 아이템 프리뷰 메쉬가 주변의 라이트 환경에 영향을 받지 않도록 독자적 채널을 사용 -> 2번
- 아이템 프리뷰 메쉬 전용 라이트 추가 - PointLight
- 최적화를 위해 컴포넌트 모빌리티 Static으로 설정

### 기타
- ShopWidget : 일부 레벨에서 NativeOnInitialized가 발동 되지 않아서 델리게이트용으로 NativeConstruct, NativeDestruct 추가

---
