### PR TITLE
Add: 수중/지상 상태 구분, Anim Montage Slot 추가

### DIFF
--- a/Content/_AbyssDiver/Blueprints/ABP/Player/ABP_Underwater.uasset
+++ b/Content/_AbyssDiver/Blueprints/ABP/Player/ABP_Underwater.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8aaee08745bbfb34d74595ace5a7c7870b43bf932fabf45830e14bc4d8ade67d
-size 397409
+oid sha256:01670e60a22d25db095a1d282e0f6ba5d99a116897eb40b1ce63309434e7166e
+size 453558

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/KKS/KKS_LocomotionTest.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/KKS/KKS_LocomotionTest.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57364b49fb045de930a499b83b8687d88f9b9d09468515f79dc84782ca2067ca
-size 93514
+oid sha256:463b6a553af433b31e86b83e1ae7fb6ad006de86f06fbbb0b8749ba1857e37db
+size 104591

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterAnimInstance.h
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterAnimInstance.h
@@ -25,12 +25,20 @@ protected:
 
 #pragma region Method
 
+protected:
+	
+	/** 캐릭터 상태 변수 업데이트 */
 	void UpdateVariables();
+
+	/** 캐릭터 기울기 업데이트 */
+	void UpdateLeanAngle();
 	
 #pragma endregion
 	
 #pragma region Variable
 
+protected:
+	
 	/** Character 약참조 */
 	UPROPERTY(BlueprintReadOnly)
 	TWeakObjectPtr<class AUnderwaterCharacter> UnderwaterCharacter;
@@ -73,12 +81,34 @@ protected:
 	UPROPERTY(BlueprintReadOnly)
 	uint8 bShouldMove : 1;
 
+	/** 캐릭터가 Groggy 상태인지 여부 */
 	UPROPERTY(BlueprintReadOnly)
 	uint8 bIsGroggy : 1;
 
+	/** 캐릭터가 Dead 상태인지 여부 */
 	UPROPERTY(BlueprintReadOnly)
 	uint8 bIsDead : 1;
 
+	/** Strafing 적용 여부. Strafing Mode일 경우 직립 상태로만 이동한다. */
+	UPROPERTY(BlueprintReadOnly)
+	uint8 bIsStrafing : 1;
+
+	/** Pelvis에 적용될 Pitch */
+	UPROPERTY(BlueprintReadOnly)
+	float ModifyPitch;
+	
+	/** Lean을 적용할 최소 속도 */
+	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	float LeanThresholdSpeed;
+
+	/** Lean을 적용할 최대 각도 */
+	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	float MaxLeanAngle;
+
+	/** Lean 적용 여부 */
+	UPROPERTY(BlueprintReadOnly)
+	uint8 bShouldLean : 1;
+	
 #pragma endregion
 
 #pragma region Getter Setter

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
@@ -26,6 +26,8 @@
 #include "Subsystems/DataTableSubsystem.h"
 #include "UI/HoldInteractionWidget.h"
 
+DEFINE_LOG_CATEGORY(LogAbyssDiverCharacter);
+
 AUnderwaterCharacter::AUnderwaterCharacter()
 {
 	FirstPersonCameraArm = CreateDefaultSubobject<USpringArmComponent>(TEXT("FirstPersonCameraArm"));

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
@@ -130,7 +130,7 @@ void AUnderwaterCharacter::BeginPlay()
 {
 	Super::BeginPlay();
 
-	SetEnvState(EnvState);
+	RootComponent->PhysicsVolumeChangedDelegate.AddDynamic(this, &AUnderwaterCharacter::OnPhysicsVolumeChanged);
 
 	SetDebugCameraMode(bUseDebugCamera);
 
@@ -275,27 +275,20 @@ void AUnderwaterCharacter::GetLifetimeReplicatedProps(TArray<class FLifetimeProp
 
 void AUnderwaterCharacter::SetEnvState(EEnvState State)
 {
+	if (EnvState == State)
+	{
+		return;
+	}
 	EnvState = State;
 
 	switch (EnvState)
 	{
 	case EEnvState::Underwater:
-		// 현재 Physics Volume을 Water로 설정한다.
-		// 현재 Physics Volume이 Water가 아닐 경우 World의 Default Volume을 반환한다.
-		// Default Volume을 Water를 설정해서 Swim Mode를 사용할 수 있도록 한다.
-		GetCharacterMovement()->GetPhysicsVolume()->bWaterVolume = true;
-		GetCharacterMovement()->SetMovementMode(MOVE_Swimming);
-		GetCharacterMovement()->bOrientRotationToMovement = false;
 		GetCharacterMovement()->GravityScale = 0.0f;
-		bUseControllerRotationYaw = true;
 		break;
 	case EEnvState::Ground:
 		// 지상에서는 이동 방향으로 회전을 하게 한다.
-		GetCharacterMovement()->GetPhysicsVolume()->bWaterVolume = false;
-		GetCharacterMovement()->SetMovementMode(MOVE_Walking);
-		GetCharacterMovement()->bOrientRotationToMovement = false;
 		GetCharacterMovement()->GravityScale = 1.0f;
-		bUseControllerRotationYaw = true;
 		break;
 	default:
 		UE_LOG(AbyssDiver, Error, TEXT("Invalid Character State"));
@@ -726,6 +719,14 @@ void AUnderwaterCharacter::OnHealthChanged(int32 CurrentHealth, int32 MaxHealth)
 		// Transition 1
 		SetCharacterState(ECharacterState::Groggy);
 	}
+}
+
+void AUnderwaterCharacter::OnPhysicsVolumeChanged(class APhysicsVolume* NewVolume)
+{
+	LOG_NETWORK(LogAbyssDiverCharacter, Display, TEXT("Physics Volume Changed : %s"), *NewVolume->GetName());
+
+	const EEnvState NewEnvState = NewVolume->bWaterVolume ? EEnvState::Underwater : EEnvState::Ground;
+	SetEnvState(NewEnvState);
 }
 
 void AUnderwaterCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.h
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.h
@@ -282,6 +282,9 @@ protected:
 	UFUNCTION()
 	void OnHealthChanged(int32 CurrentHealth, int32 MaxHealth);
 
+	UFUNCTION()
+	void OnPhysicsVolumeChanged(class APhysicsVolume* NewVolume);
+	
 	/** 이동 함수. 지상, 수중 상태에 따라 이동한다. */
 	void Move(const FInputActionValue& InputActionValue);
 

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.h
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.h
@@ -6,7 +6,19 @@
 #include "InputActionValue.h"
 #include "UnitBase.h"
 #include "Interface/IADInteractable.h"
+#include "AbyssDiverUnderWorld.h"
 #include "UnderwaterCharacter.generated.h"
+
+#if UE_BUILD_SHIPPING
+	#define LOG_ABYSS_DIVER_COMPILE_VERBOSITY Error
+#else
+	#define LOG_ABYSS_DIVER_COMPILE_VERBOSITY All
+#endif
+
+#define LOG_NETWORK(Category, Verbosity, Format, ...) \
+	UE_LOG(Category, Verbosity, TEXT("[%s] %s %s"), LOG_NETMODEINFO, LOG_CALLINFO, *FString::Printf(Format, ##__VA_ARGS__))
+
+DECLARE_LOG_CATEGORY_EXTERN(LogAbyssDiverCharacter, Log, LOG_ABYSS_DIVER_COMPILE_VERBOSITY);
 
 // @TODO : Character Status Replicate 문제
 // 1. 최대 Stamina는 최대 Oxygen에 비례하는데 값이 따로따로 Replicate될 수 있다. 이렇게 되면 항상 오차가 존재하게 된다.

--- a/Source/AbyssDiverUnderWorld/Physics/DefaultWaterPhysicsVolume.cpp
+++ b/Source/AbyssDiverUnderWorld/Physics/DefaultWaterPhysicsVolume.cpp
@@ -1,0 +1,9 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Physics/DefaultWaterPhysicsVolume.h"
+
+ADefaultWaterPhysicsVolume::ADefaultWaterPhysicsVolume()
+{
+	bWaterVolume = true;
+}

--- a/Source/AbyssDiverUnderWorld/Physics/DefaultWaterPhysicsVolume.h
+++ b/Source/AbyssDiverUnderWorld/Physics/DefaultWaterPhysicsVolume.h
@@ -1,0 +1,18 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/DefaultPhysicsVolume.h"
+#include "DefaultWaterPhysicsVolume.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ABYSSDIVERUNDERWORLD_API ADefaultWaterPhysicsVolume : public ADefaultPhysicsVolume
+{
+	GENERATED_BODY()
+
+	ADefaultWaterPhysicsVolume();
+};


### PR DESCRIPTION
---

## 📝 작업 상세 내용
<!-- 어떤 기능을 추가/수정했는지 상세히 기술해주세요 -->
- 지상 / 수중을 피직스 볼륨을 이용해서 처리
- ABP에 Slot을 추가
- 캐릭터 로깅 카테고리 추가

---

## 📸 스크린샷 (선택)
<!-- UI, 이펙트, 레벨 디자인 등 시각적 작업 시 스크린샷 첨부 -->


https://github.com/user-attachments/assets/8ef5e760-ad52-4b54-bc29-658d3a7639fb

![스크린샷 2025-05-23 204310](https://github.com/user-attachments/assets/c4432e26-3559-4ea1-b919-086d5941ca95)

---

## 🙋 리뷰어에게 요청사항
<!-- 리뷰 시 중점적으로 봐줬으면 하는 부분 -->

---

## 수중 설정 방법

맵을 기본으로 수중으로 설정하기 위해서는 Default Physics Volume을 Water로 설정해주시면 됩니다.
![스크린샷 2025-05-23 094144](https://github.com/user-attachments/assets/3044b655-46a7-4d65-9ee4-de7fb3ab1bdf)

맵의 일부분을 지상 혹은 수중으로 설정하기 위해서는 Physics Volume을 설정해주시면 됩니다.

- 배치
![스크린샷 2025-05-23 204701](https://github.com/user-attachments/assets/062015c1-571d-4d37-895e-0e6bc197b19a)

- 설정
![스크린샷 2025-05-23 204729](https://github.com/user-attachments/assets/01b2ec50-3545-48a7-b098-23281e7eaf21)


---
