### PR TITLE
🎉 add 사운드 관리 기능 추가 : SoundSubsystem, DataTables, 및 기타

### DIFF
--- a/Content/_AbyssDiver/Blueprints/Environmental_Factors/BP_Whale.uasset
+++ b/Content/_AbyssDiver/Blueprints/Environmental_Factors/BP_Whale.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a22d90a4395d672f573f974709c2d619d0ac2f9dce4c668075de9f9aebb0f638
-size 119127
+oid sha256:2e6b84e8702579d865534a6ff53eca08742bc147dcecde8c309a81d0f05460c0
+size 119968

--- a/Content/_AbyssDiver/Blueprints/Framework/BP_ADGameInstance.uasset
+++ b/Content/_AbyssDiver/Blueprints/Framework/BP_ADGameInstance.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad07aa92e4568d6395914615ece126c78b0356b73210e35214db9ceb33775ab7
-size 159448
+oid sha256:2e37d81bbf47ece846b0da67f132187ad3b4891acb41b3284bc3282245cc0868
+size 155698

--- a/Content/_AbyssDiver/DataTable/SoundData/DT_BGM.uasset
+++ b/Content/_AbyssDiver/DataTable/SoundData/DT_BGM.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5ddc58dfc8b72cf66ef3e98bc82dbaa90ef108335233d1d04d6e1d43f212d83
+size 2564

--- a/Content/_AbyssDiver/DataTable/SoundData/DT_MonsterSFX.uasset
+++ b/Content/_AbyssDiver/DataTable/SoundData/DT_MonsterSFX.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1777a337bafab3a27777e00066f22d1bbbf09720eb77a3d37dc956a92ea8a373
+size 2402

--- a/Content/_AbyssDiver/DataTable/SoundData/DT_SFX.uasset
+++ b/Content/_AbyssDiver/DataTable/SoundData/DT_SFX.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b519d09cee349a19aa0d52d0677a6510d86b11f92528c25cb23f9d4409a429b4
+size 2556

--- a/Content/_AbyssDiver/DataTable/SoundData/DT_UISFX.uasset
+++ b/Content/_AbyssDiver/DataTable/SoundData/DT_UISFX.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33fd1915956bb57cf3292c9c8589681b1f4bee00c1472cf06802f77d84e2d8bb
+size 2352

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_SoundTest.uasset
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/BP_SoundTest.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45ede2b937d568ac134ef9b89a76bcba2c61dab3a40154fe5afefa21b0d92d2a
+size 40508

--- a/Source/AbyssDiverUnderWorld/DataRow/SoundDataRow/BGMDataRow.h
+++ b/Source/AbyssDiverUnderWorld/DataRow/SoundDataRow/BGMDataRow.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+
+#include "BGMDataRow.generated.h"
+
+UENUM(BlueprintType)
+enum class ESFX_BGM : uint8
+{
+	Sound0,
+	Sound1,
+	Sound2,
+};
+
+USTRUCT(BlueprintType)
+struct FBGMDataRow : public FTableRowBase
+{
+	GENERATED_BODY()
+	
+	UPROPERTY(EditDefaultsOnly)
+	ESFX_BGM SoundType;
+
+	UPROPERTY(EditDefaultsOnly)
+	TObjectPtr<USoundBase> Sound;
+};

--- a/Source/AbyssDiverUnderWorld/DataRow/SoundDataRow/MonsterSFXDataRow.h
+++ b/Source/AbyssDiverUnderWorld/DataRow/SoundDataRow/MonsterSFXDataRow.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+
+#include "MonsterSFXDataRow.generated.h"
+
+UENUM(BlueprintType)
+enum class ESFX_Monster : uint8
+{
+	Sound0,
+	Sound1,
+	Sound2,
+};
+
+USTRUCT(BlueprintType)
+struct FMonsterSFXDataRow : public FTableRowBase
+{
+	GENERATED_BODY()
+	
+	UPROPERTY(EditDefaultsOnly)
+	ESFX_Monster SoundType;
+
+	UPROPERTY(EditDefaultsOnly)
+	TObjectPtr<USoundBase> Sound;
+};

--- a/Source/AbyssDiverUnderWorld/DataRow/SoundDataRow/SFXDataRow.h
+++ b/Source/AbyssDiverUnderWorld/DataRow/SoundDataRow/SFXDataRow.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+
+#include "SFXDataRow.generated.h"
+
+UENUM(BlueprintType)
+enum class ESFX : uint8
+{
+	Sound0,
+	Sound1,
+	Sound2,
+};
+
+USTRUCT(BlueprintType)
+struct FSFXDataRow : public FTableRowBase
+{
+	GENERATED_BODY()
+	
+	UPROPERTY(EditDefaultsOnly)
+	ESFX SoundType;
+
+	UPROPERTY(EditDefaultsOnly)
+	TObjectPtr<USoundBase> Sound;
+};

--- a/Source/AbyssDiverUnderWorld/DataRow/SoundDataRow/UISFXDataRow.h
+++ b/Source/AbyssDiverUnderWorld/DataRow/SoundDataRow/UISFXDataRow.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+
+#include "UISFXDataRow.generated.h"
+
+UENUM(BlueprintType)
+enum class ESFX_UI : uint8
+{
+	Sound0,
+	Sound1,
+	Sound2,
+};
+
+USTRUCT(BlueprintType)
+struct FUISFXDataRow : public FTableRowBase
+{
+	GENERATED_BODY()
+	
+	UPROPERTY(EditDefaultsOnly)
+	ESFX_UI SoundType;
+
+	UPROPERTY(EditDefaultsOnly)
+	TObjectPtr<USoundBase> Sound;
+};

--- a/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.cpp
@@ -1,6 +1,7 @@
 #include "Framework/ADGameInstance.h"
 
 #include "AbyssDiverUnderWorld.h"
+#include "Subsystems/SoundSubsystem.h"
 
 #include "Kismet/GameplayStatics.h"
 
@@ -57,4 +58,19 @@ void UADGameInstance::RemovePlayerNetId(const FString& NetId)
 
     ValidPlayerIndexArray[PlayerIndex - 1] = false;
     PlayerIdMap.Remove(NetId);
+}
+
+void UADGameInstance::ChangeMasterVolume(const float& NewVolume) const
+{
+    GetSubsystem<USoundSubsystem>()->ChangeMasterVolume(NewVolume);
+}
+
+void UADGameInstance::ChangeBGMVolume(const float& NewVolume) const
+{
+    GetSubsystem<USoundSubsystem>()->ChangeBGMVolume(NewVolume);
+}
+
+void UADGameInstance::ChangeSFXVolume(const float& NewVolume) const
+{
+    GetSubsystem<USoundSubsystem>()->ChangeSFXVolume(NewVolume);
 }

--- a/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.h
@@ -30,6 +30,18 @@ public:
 	void AddPlayerNetId(const FString& NetId);
 	void RemovePlayerNetId(const FString& NetId);
 
+	// 0~1의 값
+	UFUNCTION(Exec, BlueprintCallable, Category = "ADGameInstance")
+	void ChangeMasterVolume(const float& NewVolume) const;
+
+	// 0~1의 값
+	UFUNCTION(Exec, BlueprintCallable, Category = "ADGameInstance")
+	void ChangeBGMVolume(const float& NewVolume) const;
+
+	// 0~1의 값
+	UFUNCTION(Exec, BlueprintCallable, Category = "ADGameInstance")
+	void ChangeSFXVolume(const float& NewVolume) const;
+
 public:
 	UPROPERTY(BlueprintReadWrite)
 	uint8 bIsHost : 1;
@@ -61,6 +73,22 @@ public:
 
 	UPROPERTY(EditDefaultsOnly, Category = "ADGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.ShopItemMeshTransformRow"))
 	TObjectPtr<UDataTable> ShopMeshTransformTable;
+
+#pragma region Sound Tables
+
+	UPROPERTY(EditDefaultsOnly, Category = "ADGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.SFXDataRow"))
+	TObjectPtr<UDataTable> SFXDataTable;
+
+	UPROPERTY(EditDefaultsOnly, Category = "ADGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.UISFXDataRow"))
+	TObjectPtr<UDataTable> UISFXDataTable;
+
+	UPROPERTY(EditDefaultsOnly, Category = "ADGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.MonsterSFXDataRow"))
+	TObjectPtr<UDataTable> MonsterSFXDataTable;
+
+	UPROPERTY(EditDefaultsOnly, Category = "ADGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.BGMDataRow"))
+	TObjectPtr<UDataTable> BGMDataTable;
+
+#pragma endregion
 
 private:
 

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
@@ -216,7 +216,7 @@ AShop::AShop()
 	LightComp->LightingChannels.bChannel1 = false;
 	LightComp->LightingChannels.bChannel2 = true;
 
-	LightComp->SetMobility(EComponentMobility::Static);
+	LightComp->SetMobility(EComponentMobility::Stationary);
 	LightComp->SetRelativeLocation(FVector(0, 0, 100));
 
 	InteractableComp = CreateDefaultSubobject<UADInteractableComponent>(TEXT("InteractableComp"));

--- a/Source/AbyssDiverUnderWorld/Subsystems/SoundSubsystem.cpp
+++ b/Source/AbyssDiverUnderWorld/Subsystems/SoundSubsystem.cpp
@@ -1,0 +1,278 @@
+﻿#include "Subsystems/SoundSubsystem.h"
+
+#include "AbyssDiverUnderWorld.h"
+#include "Framework/ADGameInstance.h"
+
+#include "Components/AudioComponent.h"
+#include "Kismet/GameplayStatics.h"
+
+void USoundSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+
+	UADGameInstance* GI = CastChecked<UADGameInstance>(GetGameInstance());
+	GI->SFXDataTable->GetAllRows<FSFXDataRow>(TEXT("Getting SFXs.."), SFXData);
+	SFXDataCount = SFXData.Num();
+
+	Algo::Sort(SFXData, [](const FSFXDataRow* A, const FSFXDataRow* B)
+		{
+			return A->SoundType < B->SoundType;
+		});
+
+	for (int32 i = 0; i < SFXDataCount; ++i)
+	{
+		if (ensureMsgf(i == (int32)SFXData[i]->SoundType, TEXT("DT_SFX에 %d 번에 해당하는 사운드 데이터가 없습니다. 반드시 0번부터 빈 Enum 없이 채워주세요"), i) == false)
+		{
+			break;
+		}
+	}
+
+	LOGV(Warning, TEXT("SFXData is Initialized, Count : %d"), SFXDataCount);
+
+	GI->BGMDataTable->GetAllRows<FBGMDataRow>(TEXT("Getting BGMs.."), SFXBGMData);
+	SFXBGMDataCount = SFXBGMData.Num();
+
+	Algo::Sort(SFXBGMData, [](const FBGMDataRow* A, const FBGMDataRow* B)
+		{
+			return A->SoundType < B->SoundType;
+		});
+
+	for (int32 i = 0; i < SFXBGMDataCount; ++i)
+	{
+		if (ensureMsgf(i == (int32)SFXBGMData[i]->SoundType, TEXT("DT_BGM에 %d 번에 해당하는 사운드 데이터가 없습니다. 반드시 0번부터 빈 Enum 없이 채워주세요"), i) == false)
+		{
+			break;
+		}
+	}
+
+	LOGV(Warning, TEXT("SFXBGMData is Initialized, Count : %d"), SFXBGMDataCount);
+
+	GI->UISFXDataTable->GetAllRows<FUISFXDataRow>(TEXT("Getting UI SFXs.."), SFXUIData);
+	SFXUIDataCount = SFXUIData.Num();
+
+	Algo::Sort(SFXUIData, [](const FUISFXDataRow* A, const FUISFXDataRow* B)
+		{
+			return A->SoundType < B->SoundType;
+		});
+
+	for (int32 i = 0; i < SFXUIDataCount; ++i)
+	{
+		if (ensureMsgf(i == (int32)SFXUIData[i]->SoundType, TEXT("DT_UISFX에 %d 번에 해당하는 사운드 데이터가 없습니다. 반드시 0번부터 빈 Enum 없이 채워주세요"), i) == false)
+		{
+			break;
+		}
+	}
+
+	LOGV(Warning, TEXT("SFXUIData is Initialized, Count : %d"), SFXUIDataCount);
+
+	GI->MonsterSFXDataTable->GetAllRows<FMonsterSFXDataRow>(TEXT("Getting Monster SFXs.."), SFXMonsterData);
+	SFXMonsterDataCount = SFXMonsterData.Num();
+
+	Algo::Sort(SFXMonsterData, [](const FMonsterSFXDataRow* A, const FMonsterSFXDataRow* B)
+		{
+			return A->SoundType < B->SoundType;
+		});
+
+	for (int32 i = 0; i < SFXMonsterDataCount; ++i)
+	{
+		if (ensureMsgf(i == (int32)SFXMonsterData[i]->SoundType, TEXT("DT_MonsterSFX에 %d 번에 해당하는 사운드 데이터가 없습니다. 반드시 0번부터 빈 Enum 없이 채워주세요"), i) == false)
+		{
+			break;
+		}
+	}
+	
+	LOGV(Warning, TEXT("SFXMonsterData is Initialized, Count : %d"), SFXMonsterDataCount);
+}
+
+void USoundSubsystem::Play2D(ESFX SFXType, float Volume)
+{
+	PlayInternal(SFXData[int32(SFXType)]->Sound, false, true, FVector::ZeroVector, nullptr, Volume);
+}
+
+void USoundSubsystem::Play2D(ESFX_Monster SFXType, float Volume)
+{
+	PlayInternal(SFXMonsterData[int32(SFXType)]->Sound, false, true, FVector::ZeroVector, nullptr, Volume);
+}
+
+void USoundSubsystem::Play2D(ESFX_UI SFXType, float Volume)
+{
+	PlayInternal(SFXUIData[int32(SFXType)]->Sound, false, true, FVector::ZeroVector, nullptr, Volume);
+}
+
+void USoundSubsystem::PlayBGM(ESFX_BGM SFXType, float Volume)
+{
+	PlayInternal(SFXBGMData[int32(SFXType)]->Sound, true, true, FVector::ZeroVector, nullptr, Volume);
+}
+
+void USoundSubsystem::PlayAt(ESFX SFXType, const FVector& Position, float Volume)
+{
+	PlayInternal(SFXData[int32(SFXType)]->Sound, false, false, Position, nullptr, Volume);
+}
+
+void USoundSubsystem::PlayAt(ESFX_Monster SFXType, const FVector& Position, float Volume)
+{
+	PlayInternal(SFXMonsterData[int32(SFXType)]->Sound, false, true, Position, nullptr, Volume);
+}
+
+void USoundSubsystem::PlayAt(ESFX_UI SFXType, const FVector& Position, float Volume)
+{
+	PlayInternal(SFXUIData[int32(SFXType)]->Sound, false, false, Position, nullptr, Volume);
+}
+
+void USoundSubsystem::PlayAttach(ESFX SFXType, USceneComponent* AttachComp, float Volume)
+{
+	PlayInternal(SFXData[int32(SFXType)]->Sound, false, false, FVector::ZeroVector, AttachComp, Volume);
+}
+
+void USoundSubsystem::PlayAttach(ESFX_Monster SFXType, USceneComponent* AttachComp, float Volume)
+{
+	PlayInternal(SFXMonsterData[int32(SFXType)]->Sound, false, false, FVector::ZeroVector, AttachComp, Volume);
+}
+
+void USoundSubsystem::PlayAttach(ESFX_UI SFXType, USceneComponent* AttachComp, float Volume)
+{
+	PlayInternal(SFXUIData[int32(SFXType)]->Sound, false, false, FVector::ZeroVector, AttachComp, Volume);
+}
+
+void USoundSubsystem::StopAllBGM()
+{
+	for (const auto& ActivatedBGM : ActivatedBGMComponents)
+	{
+		ActivatedBGM.Key->Stop();
+	}
+}
+
+void USoundSubsystem::StopAllSFX()
+{
+	for (const auto& ActivatedSFX : ActivatedSFXComponents)
+	{
+		ActivatedSFX.Key->Stop();
+	}
+}
+
+void USoundSubsystem::ChangeMasterVolume(float NewMasterVolume)
+{
+	MasterVolume = FMath::Clamp(NewMasterVolume, 0, 1);
+	ChangeVolumeInternal();
+}
+
+void USoundSubsystem::ChangeBGMVolume(float NewBGMVolume)
+{
+	BGMVolume = FMath::Clamp(NewBGMVolume, 0, 1);
+	ChangeVolumeInternal();
+}
+
+void USoundSubsystem::ChangeSFXVolume(float NewSFXVolume)
+{
+	SFXVolume = FMath::Clamp(NewSFXVolume, 0, 1);
+	ChangeVolumeInternal();
+}
+
+void USoundSubsystem::ChangeVolumeInternal()
+{
+	for (const auto& BGM : ActivatedBGMComponents)
+	{
+		BGM.Key->SetVolumeMultiplier(MasterVolume * BGMVolume * BGM.Value);
+	}
+
+	for (const auto& SFX : ActivatedSFXComponents)
+	{
+		SFX.Key->SetVolumeMultiplier(MasterVolume * SFXVolume * SFX.Value);
+	}
+}
+
+void USoundSubsystem::OnAudioFinished(UAudioComponent* FinishedAudio)
+{
+	bool bIsBGM = true;
+	if (ActivatedBGMComponents.Contains(FinishedAudio))
+	{
+		ActivatedBGMComponents.Remove(FinishedAudio);
+	}
+	else
+	{
+		ActivatedSFXComponents.Remove(FinishedAudio);
+		bIsBGM = false;
+	}
+
+	if (::IsValid(FinishedAudio) == false || FinishedAudio->IsValidLowLevel() == false)
+	{
+		LOGV(Warning, TEXT("Trying to Deactivated, But Not Valid"));
+		return;
+	}
+	
+	if (FinishedAudio->GetAttachParent())
+	{
+		FDetachmentTransformRules Rule(EDetachmentRule::KeepWorld, false);
+		FinishedAudio->DetachFromComponent(Rule);
+		LOGV(Warning, TEXT("Detached"));
+	}
+
+	FinishedAudio->OnAudioFinishedNative.RemoveAll(this);
+	DeactivatedComponents.Enqueue(FinishedAudio);
+	FinishedAudio->UnregisterComponent();
+
+	LOGV(Warning, TEXT("OnAudioFinished, Actvated : %d, Deactivated Empty? : %d"), (bIsBGM ? ActivatedBGMComponents.Num() : ActivatedSFXComponents.Num()), DeactivatedComponents.IsEmpty());
+}
+
+void USoundSubsystem::PlayInternal(USoundBase* SoundAsset, bool bIsBGM, bool bIs2D, const FVector& Position, USceneComponent* AttachComp, float Volume)
+{
+	TObjectPtr<UAudioComponent> NewAudio = nullptr;
+
+	while (true)
+	{
+		if (DeactivatedComponents.IsEmpty())
+		{
+			NewAudio = NewObject<UAudioComponent>((UObject*)UGameplayStatics::GetGameState(GetWorld()));
+			break;
+		}
+		else if(DeactivatedComponents.Dequeue(NewAudio) && ::IsValid(NewAudio) && NewAudio->IsValidLowLevel())
+		{
+			break;
+		}
+	}
+	
+	NewAudio->RegisterComponent();
+
+	float NewVolume = MasterVolume * Volume;
+
+	if (bIsBGM)
+	{
+		check(ActivatedBGMComponents.Contains(NewAudio) == false);
+		ActivatedBGMComponents.Add(NewAudio, Volume);
+		NewVolume *= BGMVolume;
+		LOGV(Warning, TEXT("Play Internal, Actvated : %d, Deactivated Empty? : %d"), ActivatedBGMComponents.Num(), DeactivatedComponents.IsEmpty());
+	}
+	else
+	{
+		check(ActivatedSFXComponents.Contains(NewAudio) == false);
+		ActivatedSFXComponents.Add(NewAudio, Volume);
+		NewVolume *= SFXVolume;
+		LOGV(Warning, TEXT("Play Internal, Actvated : %d, Deactivated Empty? : %d"), ActivatedSFXComponents.Num(), DeactivatedComponents.IsEmpty());
+	}
+
+	NewAudio->SetSound(SoundAsset);
+	NewAudio->SetVolumeMultiplier(NewVolume);
+
+	if (bIs2D)
+	{
+		NewAudio->bAllowSpatialization = false;
+		NewAudio->SetUISound(true);
+	}
+	else
+	{
+		NewAudio->bAllowSpatialization = true;
+		NewAudio->SetUISound(false);
+		NewAudio->SetWorldLocation(Position);
+		LOGV(Warning, TEXT("Located to : %s"), *Position.ToString());
+	}
+	
+	if (AttachComp)
+	{
+		FAttachmentTransformRules Rule(EAttachmentRule::KeepRelative, false);
+		NewAudio->AttachToComponent(AttachComp, Rule);
+		LOGV(Warning, TEXT("Attached to : %s"), *AttachComp->GetName());
+	}
+
+	NewAudio->OnAudioFinishedNative.AddUObject(this, &USoundSubsystem::OnAudioFinished);
+	NewAudio->Play();
+}

--- a/Source/AbyssDiverUnderWorld/Subsystems/SoundSubsystem.h
+++ b/Source/AbyssDiverUnderWorld/Subsystems/SoundSubsystem.h
@@ -1,0 +1,107 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+
+#include "DataRow/SoundDataRow/BGMDataRow.h"
+#include "DataRow/SoundDataRow/MonsterSFXDataRow.h"
+#include "DataRow/SoundDataRow/SFXDataRow.h"
+#include "DataRow/SoundDataRow/UISFXDataRow.h"
+
+#include "SoundSubsystem.generated.h"
+
+/**
+ * 
+ */
+UCLASS(BlueprintType)
+class ABYSSDIVERUNDERWORLD_API USoundSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+protected:
+
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+
+#pragma region Methods
+
+public:
+
+	void Play2D(ESFX SFXType, float Volume = 1.0f);
+	void Play2D(ESFX_Monster SFXType, float Volume = 1.0f);
+	void Play2D(ESFX_UI SFXType, float Volume = 1.0f);
+	void PlayBGM(ESFX_BGM SFXType, float Volume = 1.0f);
+
+	void PlayAt(ESFX SFXType, const FVector& Position, float Volume = 1.0f);
+	void PlayAt(ESFX_Monster SFXType, const FVector& Position, float Volume = 1.0f);
+	void PlayAt(ESFX_UI SFXType, const FVector& Position, float Volume = 1.0f);
+
+	void PlayAttach(ESFX SFXType, USceneComponent* AttachComp, float Volume = 1.0f);
+	void PlayAttach(ESFX_Monster SFXType, USceneComponent* AttachComp, float Volume = 1.0f);
+	void PlayAttach(ESFX_UI SFXType, USceneComponent* AttachComp, float Volume = 1.0f);
+
+	void StopAllBGM();
+	void StopAllSFX();
+
+	// 0~1의 값
+	void ChangeMasterVolume(float NewMasterVolume);
+
+	// 0~1의 값
+	void ChangeBGMVolume(float NewBGMVolume);
+
+	// 0~1의 값
+	void ChangeSFXVolume(float NewSFXVolume);
+
+private:
+
+	void ChangeVolumeInternal();
+
+	void OnAudioFinished(UAudioComponent* FinishedAudio);
+
+	void PlayInternal(USoundBase* SoundAsset, bool bIsBGM = false, bool bIs2D = true, const FVector& Position = FVector::ZeroVector, USceneComponent* AttachComp = nullptr, float Volume = 1.0f);
+
+#pragma endregion
+
+#pragma region Variables
+
+private:
+
+	TArray<FSFXDataRow*> SFXData;
+
+	TArray<FMonsterSFXDataRow*> SFXMonsterData;
+
+	TArray<FUISFXDataRow*> SFXUIData;
+
+	TArray<FBGMDataRow*> SFXBGMData;
+
+	// 원래 볼륨을 Value로 저장
+	UPROPERTY()
+	TMap<TObjectPtr<UAudioComponent>, float> ActivatedSFXComponents;
+
+	// 원래 볼륨을 Value로 저장
+	UPROPERTY()
+	TMap<TObjectPtr<UAudioComponent>, float> ActivatedBGMComponents;
+
+	TQueue<TObjectPtr<UAudioComponent>> DeactivatedComponents;
+
+	int32 SFXDataCount = 0;
+	int32 SFXMonsterDataCount = 0;
+	int32 SFXUIDataCount = 0;
+	int32 SFXBGMDataCount = 0;
+
+	float MasterVolume = 1.0f;
+	float BGMVolume = 1.0f;
+	float SFXVolume = 1.0f;
+
+#pragma endregion
+
+#pragma region Getters / Setters
+
+public:
+
+	FORCEINLINE float GetMasterVolume() const { return MasterVolume; }
+	FORCEINLINE float GetBGMVolume() const { return BGMVolume; }
+	FORCEINLINE float GetSFXVolume() const { return SFXVolume; }
+
+#pragma endregion
+
+};


### PR DESCRIPTION


---

## 📝 작업 상세 내용
### SoundSubsystem
- 사운드 데이터를 관리함과 동시에 사운드 재생 및 풀링 담당
- 사운드 종류를 BGM, Monster, UI, 그 외로 나눔
- 다만 설정상으로는 BGM과 SFX 두 종류로 관리함

문서 참고
https://teamsparta.notion.site/1ff2dc3ef51480968733c09b161bb6d9

### 기타
- Shop : Light를 Static에서 Stationary로 변경 - Static을 사용할 수 없다는 경고 메세지 때문..
- BP_Whale : 초기에는 Tick 비활성화, 이후 이벤트가 발동되면 Tick활성화 되도록 변경 - 대영님 피드백 반영

---

## 📸 스크린샷 (선택)
### BP_Whale 로직 변경 사항 : 이벤트 발동 전에는 Tick 비활성화, 이벤트 발동 후 Tick 활성화로 변경
![image](https://github.com/user-attachments/assets/00928470-c5ec-4a77-bc40-cd4b1f05791d)
![image](https://github.com/user-attachments/assets/d79316ba-49b3-486a-821a-fe83b46fec7c)


---

