### PR TITLE
[Update] Behavior Tree Instance 관련 버그 해결

### DIFF
--- a/Content/_AbyssDiver/Blueprints/ABP/Boss/AlienShark/ABP_AlienShark.uasset
+++ b/Content/_AbyssDiver/Blueprints/ABP/Boss/AlienShark/ABP_AlienShark.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da4c21ea252881d222a224206f2240e74e4ff2b1f3c93c88f6de0851b44202b0
-size 136539
+oid sha256:55ab2e888a7f48284a84e353eb5427676f2f5772d859d92ded1511be91a5fcfe
+size 142387

--- a/Content/_AbyssDiver/Blueprints/ABP/Boss/AlienShark/BS_AlienShark.uasset
+++ b/Content/_AbyssDiver/Blueprints/ABP/Boss/AlienShark/BS_AlienShark.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9a2adbf7c8c3e8b3eba6663fb633f47a2e5fae1f6b819fa9e7d62bdd0b40caa
-size 9288
+oid sha256:dfeceef314242a76f2bbd7f86aa3166c3cb4ac9ee2446b8284d05195b923e83a
+size 9287

--- a/Content/_AbyssDiver/Blueprints/Boss/AlienShark/AIC_EnhancedBossController.uasset
+++ b/Content/_AbyssDiver/Blueprints/Boss/AlienShark/AIC_EnhancedBossController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a44ecba7f571a52d1c18599c1b68749e238c89c5f8a4f1fe54b74dba07abd61c
-size 23103
+oid sha256:ecf3ca963004d63c487522dda5455ff19f0598488e3fecb630031ac4c45f8d47
+size 23001

--- a/Content/_AbyssDiver/Blueprints/Boss/AlienShark/BP_AlienShark.uasset
+++ b/Content/_AbyssDiver/Blueprints/Boss/AlienShark/BP_AlienShark.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9cf62ca398c7894051b62773f41468d10c51f0cce53b34ed8e8aa3ef37bc1a12
-size 43941
+oid sha256:7c8aa07babbdbf731eb5bfc2b17da31c69b07178693b6c23363ea877bdd39fd8
+size 44203

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/KDYTest/KDY_Blood_Effect.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/KDYTest/KDY_Blood_Effect.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:60adf3fe65807f589c71d1fd30b9aa88a8e86dcf1c70f7a03168edfbb26b9e5b
-size 562415
+oid sha256:51fbc8bc0ac37c09f8383b29ba6e5c182e1618e30475150c8e115c0c8e0c9cb6
+size 888552

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/KY/Shallow.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/KY/Shallow.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f29ac3dc123ea5374047985e9dc1ba0abc058530e13702bdd538191e41eed00c
-size 129418688
+oid sha256:915d44e1ae364fa0768d53c150b95df04dd0bc0f891842e073aee0e4b9788613
+size 129418741

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/KY/Shallow.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/KY/Shallow.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:190e34dd3c4e4b6fc7d0de596fbfd6a7f605bc7d23b2f06d41cfd1c222f018b6
-size 129422243
+oid sha256:f29ac3dc123ea5374047985e9dc1ba0abc058530e13702bdd538191e41eed00c
+size 129418688

--- a/Source/AbyssDiverUnderWorld/Boss/AlienShark/AlienShark.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/AlienShark/AlienShark.cpp
@@ -17,5 +17,4 @@ void AAlienShark::BeginPlay()
 	Super::BeginPlay();
 
 	BiteCollision->OnComponentBeginOverlap.AddDynamic(this, &ABoss::OnMeshOverlapBegin);
-	GetCharacterMovement()->MaxFlySpeed = 0.0f;
 }

--- a/Source/AbyssDiverUnderWorld/Boss/Boss.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Boss.cpp
@@ -22,7 +22,6 @@ const FName ABoss::BossStateKey = "BossState";
 
 ABoss::ABoss()
 {
-	PrimaryActorTick.bCanEverTick = true;
 	bIsAttackCollisionOverlappedPlayer = false;
 	BlackboardComponent = nullptr;
 	AIController = nullptr;
@@ -37,6 +36,7 @@ ABoss::ABoss()
 	bShouldDecelerate = false;
 	BossPhysicsType = EBossPhysicsType::None;
 	DamagedLocation = FVector::ZeroVector;
+	CachedSpawnLocation = FVector::ZeroVector;
 	Acceleration = 2.f;
 	CurrentMoveSpeed = 0.0f;
 	RotationInterpSpeed = 1.1f;
@@ -73,17 +73,12 @@ void ABoss::BeginPlay()
 		BlackboardComponent = AIController->GetBlackboardComponent();
 	}
 
+	CachedSpawnLocation = GetActorLocation();
+
 	AttackCollision->OnComponentBeginOverlap.AddDynamic(this, &ABoss::OnAttackCollisionOverlapBegin);
 	AttackCollision->OnComponentEndOverlap.AddDynamic(this, &ABoss::OnAttackCollisionOverlapEnd);
 
 	GetCharacterMovement()->MaxFlySpeed = StatComponent->GetMoveSpeed();
-}
-
-void ABoss::Tick(float DeltaSeconds)
-{
-	Super::Tick(DeltaSeconds);
-
-	MoveForward(DeltaSeconds);
 }
 
 void ABoss::GetLifetimeReplicatedProps(TArray<class FLifetimeProperty>& OutLifetimeProps) const

--- a/Source/AbyssDiverUnderWorld/Boss/Boss.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Boss.cpp
@@ -1,6 +1,7 @@
 #include "Boss/Boss.h"
 #include "AbyssDiverUnderWorld.h"
 #include "EngineUtils.h"
+#include "EnhancedBossAIController.h"
 #include "Enum/EBossPhysicsType.h"
 #include "Enum/EBossState.h"
 #include "BehaviorTree/BlackboardComponent.h"
@@ -16,6 +17,7 @@
 #include "Net/UnrealNetwork.h"
 #include "NavigationSystem.h"
 #include "NiagaraFunctionLibrary.h"
+#include "Enum/EPerceptionType.h"
 #include "Perception/AISense_Damage.h"
 
 const FName ABoss::BossStateKey = "BossState";
@@ -33,12 +35,9 @@ ABoss::ABoss()
 	MaxPatrolDistance = 1000.0f;
 	AttackedCameraShakeScale = 1.0f;
 	bIsBiteAttackSuccess = false;
-	bShouldDecelerate = false;
 	BossPhysicsType = EBossPhysicsType::None;
 	DamagedLocation = FVector::ZeroVector;
 	CachedSpawnLocation = FVector::ZeroVector;
-	Acceleration = 2.f;
-	CurrentMoveSpeed = 0.0f;
 	RotationInterpSpeed = 1.1f;
 	
 	AutoPossessAI = EAutoPossessAI::PlacedInWorldOrSpawned;
@@ -115,33 +114,6 @@ void ABoss::LaunchPlayer(AUnderwaterCharacter* Player, const float& Power) const
 			Player->GetCharacterMovement()->SetMovementMode(MOVE_Swimming);	
 		}
 	}, 0.5f, false);
-}
-
-void ABoss::InitializeRotation(const float& InDeltaTime)
-{
-	FRotator CurrentRotation = GetActorRotation();
-
-	// Pitch와 Roll만 보간하고, Yaw는 유지
-	const FRotator TargetRotation = FRotator(0.f, CurrentRotation.Yaw, 0.f);
-
-	CurrentRotation = FMath::RInterpTo(CurrentRotation, TargetRotation, InDeltaTime, RotationInterpSpeed);
-	
-	SetActorRotation(CurrentRotation);
-}
-
-void ABoss::MoveForward(const float& InDeltaTime)
-{
-	// 목표 속도 계산
-	const float TargetSpeed = bShouldDecelerate ? 100.0f : StatComponent->GetMoveSpeed();
-	
-	// 목표 속도까지 부드럽게 가속
-	CurrentMoveSpeed = FMath::FInterpTo(CurrentMoveSpeed, TargetSpeed, InDeltaTime, Acceleration);
-	
-	// 실제 이동
-	const FVector MoveDelta = GetActorForwardVector() * CurrentMoveSpeed * InDeltaTime;
-	
-	// 충돌 적용
-	SetActorLocation(GetActorLocation() + MoveDelta, true);
 }
 
 float ABoss::TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent, class AController* EventInstigator,
@@ -247,6 +219,7 @@ void ABoss::Attack()
 	
 	if (IsValid(NormalAttackAnimations[AttackType]))
 	{
+		AnimInstance->OnMontageEnded.AddDynamic(this, &ABoss::OnAttackMontageEnded);
 		M_PlayAnimation(NormalAttackAnimations[AttackType]);
 	}
 }
@@ -278,8 +251,25 @@ void ABoss::M_PlayAnimation_Implementation(class UAnimMontage* AnimMontage, floa
 	PlayAnimMontage(AnimMontage, InPlayRate, StartSectionName);
 }
 
+void ABoss::OnAttackMontageEnded(UAnimMontage* Montage, bool bInterrupted)
+{
+	LOG(TEXT("OnAttackMontageEnded: %s"), *Montage->GetName());
+	AEnhancedBossAIController* EnhancedBossAIController = Cast<AEnhancedBossAIController>(GetController());
+	if (IsValid(AIController))
+	{
+		EnhancedBossAIController->GetBlackboardComponent()->SetValueAsBool("bHasDetectedPlayer", false);
+		EnhancedBossAIController->SetBlackboardPerceptionType(EPerceptionType::Finish);	
+	}
+
+	// 자신 제거
+	if (IsValid(AnimInstance))
+	{
+		AnimInstance->OnMontageEnded.RemoveDynamic(this, &ABoss::OnAttackMontageEnded);
+	}
+}
+
 void ABoss::OnMeshOverlapBegin(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp,
-	int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
+                               int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
 {
 	// 사망 상태면 얼리 리턴
 	if (BossState == EBossState::Death) return;

--- a/Source/AbyssDiverUnderWorld/Boss/Boss.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Boss.h
@@ -21,7 +21,6 @@ public:
 
 protected:
 	virtual void BeginPlay() override;
-	virtual void Tick(float DeltaSeconds) override;
 	virtual void GetLifetimeReplicatedProps(TArray<class FLifetimeProperty>& OutLifetimeProps) const override;
 
 #pragma region Method
@@ -183,6 +182,7 @@ private:
 	uint8 bIsBiteAttackSuccess : 1;
 	uint8 bIsAttackCollisionOverlappedPlayer : 1;
 	uint8 bShouldDecelerate : 1;
+	FVector CachedSpawnLocation;
 	
 #pragma endregion
 
@@ -209,6 +209,7 @@ public:
 	FORCEINLINE void InitCachedTarget() { CachedTargetPlayer = nullptr; };
 	FORCEINLINE void InitCurrentMoveSpeed() { CurrentMoveSpeed = 0.f; bShouldDecelerate = false; };
 	FORCEINLINE void SetDecelerate(const uint8 InDecelerate) { bShouldDecelerate = InDecelerate; };
+	FORCEINLINE FVector GetCachedSpawnLocation() const { return CachedSpawnLocation; }
 
 	AActor* GetTargetPoint();
 	const FVector GetTargetPointLocation() const;

--- a/Source/AbyssDiverUnderWorld/Boss/Boss.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Boss.h
@@ -28,11 +28,6 @@ public:
 	FVector GetNextPatrolPoint();
 	void SetBossState(EBossState State);
 	void LaunchPlayer(AUnderwaterCharacter* Player, const float& Power) const;
-
-	void InitializeRotation(const float& InDeltaTime);
-
-	/** 전방을 향해 이동하는 함수 */
-	void MoveForward(const float& InDeltaTime);
 	
 	/** 데미지를 받을 때 호출하는 함수 */
 	virtual float TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent, class AController* EventInstigator, AActor* DamageCauser) override;
@@ -64,6 +59,9 @@ public:
 	virtual void M_PlayAnimation_Implementation(UAnimMontage* AnimMontage, float InPlayRate = 1, FName StartSectionName = NAME_None);
 
 	UFUNCTION()
+	void OnAttackMontageEnded(UAnimMontage* Montage, bool bInterrupted);
+
+	UFUNCTION()
 	void OnMeshOverlapBegin(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, 
 							UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, 
 							bool bFromSweep, const FHitResult& SweepResult);
@@ -93,12 +91,6 @@ private:
 public:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Boss|Stat")
 	float RotationInterpSpeed;
-    	
-	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Boss|Stat")
-	float CurrentMoveSpeed;
-	
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Boss|Stat")
-	float Acceleration;
 	
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Boss|Stat")
 	EBossPhysicsType BossPhysicsType;
@@ -181,7 +173,6 @@ private:
 	uint8 CurrentPatrolPointIndex = 0;
 	uint8 bIsBiteAttackSuccess : 1;
 	uint8 bIsAttackCollisionOverlappedPlayer : 1;
-	uint8 bShouldDecelerate : 1;
 	FVector CachedSpawnLocation;
 	
 #pragma endregion
@@ -207,8 +198,6 @@ public:
 	FORCEINLINE AUnderwaterCharacter* GetCachedTarget() const { return CachedTargetPlayer; };
 	FORCEINLINE void SetCachedTarget(AUnderwaterCharacter* Target) { CachedTargetPlayer = Target; };
 	FORCEINLINE void InitCachedTarget() { CachedTargetPlayer = nullptr; };
-	FORCEINLINE void InitCurrentMoveSpeed() { CurrentMoveSpeed = 0.f; bShouldDecelerate = false; };
-	FORCEINLINE void SetDecelerate(const uint8 InDecelerate) { bShouldDecelerate = InDecelerate; };
 	FORCEINLINE FVector GetCachedSpawnLocation() const { return CachedSpawnLocation; }
 
 	AActor* GetTargetPoint();

--- a/Source/AbyssDiverUnderWorld/Boss/EnhancedBossAIController.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/EnhancedBossAIController.cpp
@@ -52,11 +52,15 @@ void AEnhancedBossAIController::InitVariables()
 	Boss->InitTarget();
 	Boss->InitCachedTarget();
 
+	// 타겟 사라짐 변수 초기화
+	bIsDisappearPlayer = false;
+
 	// 블랙보드 값 초기화
 	BlackboardComponent->SetValueAsBool(bIsChasingKey, false);
 	BlackboardComponent->SetValueAsBool(bHasDetectedPlayerKey, false);
 	BlackboardComponent->SetValueAsBool(bHasAttackedKey, false);
 	BlackboardComponent->SetValueAsBool(bIsPlayerHiddenKey, false);
+	BlackboardComponent->SetValueAsBool(bHasSeenPlayerKey, false);
 	SetBlackboardPerceptionType(EPerceptionType::None);
 }
 
@@ -65,10 +69,16 @@ void AEnhancedBossAIController::OnTargetPerceptionUpdatedHandler(AActor* Actor, 
 	// --------------------- 시각 자극 ---------------------
 	// 플레이어가 시야각에 들어오는 경우
 	if (Stimulus.Type == UAISense::GetSenseID<UAISense_Sight>())
-	{
+	{	
 		// 감지한 대상이 플레이어가 아닌 경우 얼리 리턴
 		AUnderwaterCharacter* Player = Cast<AUnderwaterCharacter>(Actor);
 		if (!IsValid(Player)) return;
+
+		// 플레이어가 사망 상태인 경우 얼리 리턴
+		if (Player->GetCharacterState() == ECharacterState::Death)
+		{
+			return;
+		}
 
 		// 전에 감지한 플레이어와 다른 경우 얼리 리턴
 		if (IsValid(Boss->GetTarget()))

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_BloodDetected.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_BloodDetected.cpp
@@ -31,7 +31,6 @@ EBTNodeResult::Type UBTTask_BloodDetected::ExecuteTask(UBehaviorTreeComponent& C
 	if (!IsValid(Boss)) return EBTNodeResult::Failed;
 	
 	Boss->SetBossState(EBossState::Idle);
-	Boss->SetDecelerate(true);
 	
 	AccumulatedTime = 0;
 	

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_BloodDetected.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_BloodDetected.cpp
@@ -15,8 +15,6 @@ UBTTask_BloodDetected::UBTTask_BloodDetected()
 {
 	NodeName = "Blood Detected";
 	bNotifyTick = true;
-	Boss = nullptr;
-	AIController = nullptr;
 	BloodOccurredLocation = FVector::ZeroVector;
 	AccumulatedTime = 0;
 	DetectedStateInterval = 2.f;
@@ -24,10 +22,10 @@ UBTTask_BloodDetected::UBTTask_BloodDetected()
 
 EBTNodeResult::Type UBTTask_BloodDetected::ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory)
 {
-	AIController = Cast<AEnhancedBossAIController>(Comp.GetAIOwner());
+	AEnhancedBossAIController* AIController = Cast<AEnhancedBossAIController>(Comp.GetAIOwner());
 	if (!IsValid(AIController)) return EBTNodeResult::Failed;
 
-	Boss = Cast<ABoss>(AIController->GetCharacter());
+	ABoss* Boss = Cast<ABoss>(AIController->GetCharacter());
 	if (!IsValid(Boss)) return EBTNodeResult::Failed;
 	
 	Boss->SetBossState(EBossState::Idle);
@@ -44,6 +42,12 @@ void UBTTask_BloodDetected::TickTask(UBehaviorTreeComponent& Comp, uint8* NodeMe
 {
 	Super::TickTask(Comp, NodeMemory, DeltaSeconds);
 
+	AEnhancedBossAIController* AIController = Cast<AEnhancedBossAIController>(Comp.GetAIOwner());
+	if (!IsValid(AIController)) return;
+
+	ABoss* Boss = Cast<ABoss>(AIController->GetCharacter());
+	if (!IsValid(Boss)) return;
+	
 	Boss->RotationToTarget(BloodOccurredLocation);
 
 	if (AccumulatedTime > DetectedStateInterval)

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_BloodDetected.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_BloodDetected.h
@@ -19,12 +19,6 @@ private:
 
 private:
 	UPROPERTY()
-	TObjectPtr<ABoss> Boss;
-
-	UPROPERTY()
-	TObjectPtr<AEnhancedBossAIController> AIController;
-
-	UPROPERTY()
 	FVector BloodOccurredLocation;
 
 	UPROPERTY()

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_ChangePerceptionType.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_ChangePerceptionType.cpp
@@ -5,18 +5,18 @@
 UBTTask_ChangePerceptionType::UBTTask_ChangePerceptionType()
 {
 	NodeName = "Change Perception Type";
-	bNotifyTick = true;
-	Boss = nullptr;
-	AIController = nullptr;
+	bNotifyTick = false;
+	bCreateNodeInstance = false;
+	
 	PerceptionType = EPerceptionType::None;
 }
 
 EBTNodeResult::Type UBTTask_ChangePerceptionType::ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory)
 {
-	AIController = Cast<AEnhancedBossAIController>(Comp.GetAIOwner());
+	AEnhancedBossAIController* AIController = Cast<AEnhancedBossAIController>(Comp.GetAIOwner());
 	if (!IsValid(AIController)) return EBTNodeResult::Failed;
 
-	Boss = Cast<ABoss>(AIController->GetCharacter());
+	ABoss* Boss = Cast<ABoss>(AIController->GetCharacter());
 	if (!IsValid(Boss)) return EBTNodeResult::Failed;
 
 	AIController->SetBlackboardPerceptionType(PerceptionType);	

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_ChangePerceptionType.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_ChangePerceptionType.h
@@ -17,12 +17,6 @@ private:
 	virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory) override;
 
 private:
-	UPROPERTY()
-	TObjectPtr<ABoss> Boss;
-
-	UPROPERTY()
-	TObjectPtr<AEnhancedBossAIController> AIController;
-
 	UPROPERTY(EditAnywhere)
 	EPerceptionType PerceptionType;
 	

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_Damaged.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_Damaged.cpp
@@ -29,7 +29,6 @@ EBTNodeResult::Type UBTTask_Damaged::ExecuteTask(UBehaviorTreeComponent& Comp, u
 	if (!IsValid(Boss)) return EBTNodeResult::Failed;
 
 	Boss->SetBossState(EBossState::Idle);
-	Boss->SetDecelerate(true);
 	
 	AccumulatedTime = 0.0f;
 	TimeCriteria = FMath::RandRange(MinRotationTime, MaxRotationTime);

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_Damaged.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_Damaged.h
@@ -5,6 +5,21 @@
 #include "Boss/EnhancedBossAIController.h"
 #include "BTTask_Damaged.generated.h"
 
+struct FBTDamagedTaskMemory
+{
+	/** 빙의한 AIController에 대한 참조 */
+	TWeakObjectPtr<AEnhancedBossAIController> AIController;
+
+	/** AIController의 주체에 대한 참조 */
+	TWeakObjectPtr<ABoss> Boss;
+
+	/** 현재까지 경과된 시간 */
+	float AccumulatedTime;
+
+	/** Damaged 작업이 끝나는 시간 */
+	float FinishTaskInterval;
+};
+
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API UBTTask_Damaged : public UBTTask_BlackboardBase
 {
@@ -16,15 +31,9 @@ public:
 private:
 	virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory) override;
 	virtual void TickTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory, float DeltaSeconds) override;
-	virtual void OnTaskFinished(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, EBTNodeResult::Type TaskResult) override;
+	virtual uint16 GetInstanceMemorySize() const override { return sizeof(FBTDamagedTaskMemory); }
 
 private:
-	UPROPERTY()
-	TObjectPtr<ABoss> Boss;
-
-	UPROPERTY()
-	TObjectPtr<AEnhancedBossAIController> AIController;
-
 	UPROPERTY(EditAnywhere)
 	float MaxRotationTime;
 
@@ -33,11 +42,5 @@ private:
 
 	UPROPERTY(EditAnywhere)
 	float RotationStartTime;
-
-	UPROPERTY()
-	float AccumulatedTime;
-
-	UPROPERTY()
-	float TimeCriteria;
 	
 };

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_EnhancedAttack.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_EnhancedAttack.h
@@ -5,6 +5,18 @@
 #include "Boss/EnhancedBossAIController.h"
 #include "BTTask_EnhancedAttack.generated.h"
 
+struct FBTEnhancedAttackTaskMemory
+{
+	/** 빙의한 AIController에 대한 참조 */
+	TWeakObjectPtr<AEnhancedBossAIController> AIController;
+
+	/** AIController의 주체에 대한 참조 */
+	TWeakObjectPtr<ABoss> Boss;
+
+	/** 노드에 할당된 블랙보드 키 이름 */
+	FName BlackboardKeyName;
+};
+
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API UBTTask_EnhancedAttack : public UBTTask_BlackboardBase
 {
@@ -16,21 +28,6 @@ public:
 private:
 	virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory) override;
 	virtual void TickTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory, float DeltaSeconds) override;
-
-	UFUNCTION()
-	void FinishPerception(UAnimMontage* Montage, bool bInterrupted);
-
-private:
-	UPROPERTY()
-	TObjectPtr<ABoss> Boss;
-
-	UPROPERTY()
-	TObjectPtr<AEnhancedBossAIController> AIController;
-
-	UPROPERTY()
-	TObjectPtr<UAnimInstance> AnimInstance;
-
-	UPROPERTY()
-	FName BlackboardKeyName;
+	virtual uint16 GetInstanceMemorySize() const override { return sizeof(FBTEnhancedAttackTaskMemory); }
 	
 };

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_EnhancedIdle.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_EnhancedIdle.cpp
@@ -23,7 +23,6 @@ EBTNodeResult::Type UBTTask_EnhancedIdle::ExecuteTask(UBehaviorTreeComponent& Co
 	if (!IsValid(Boss)) return EBTNodeResult::Failed;
 
 	Boss->SetBossState(EBossState::Idle);
-	Boss->SetDecelerate(true);
 
 	AccumulatedTime = 0.f;
 	IdleFinishTime = FMath::RandRange(IdleFinishMinInterval, IdleFinishMaxInterval);

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_EnhancedIdle.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_EnhancedIdle.h
@@ -5,6 +5,21 @@
 #include "Boss/EnhancedBossAIController.h"
 #include "BTTask_EnhancedIdle.generated.h"
 
+struct FBTIdleTaskMemory
+{
+	/** 빙의한 AIController에 대한 참조 */
+	TWeakObjectPtr<AEnhancedBossAIController> AIController;
+
+	/** AIController의 주체에 대한 참조 */
+	TWeakObjectPtr<ABoss> Boss;
+	
+	/** 현재까지 경과된 시간 */
+	float AccumulatedTime;
+
+	/** Idle 작업이 끝나는 시간 */
+	float IdleFinishTime;
+};
+
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API UBTTask_EnhancedIdle : public UBTTask_BlackboardBase
 {
@@ -16,20 +31,9 @@ public:
 private:
 	virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory) override;
 	virtual void TickTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory, float DeltaSeconds) override;
-
+	virtual uint16 GetInstanceMemorySize() const override { return sizeof(FBTIdleTaskMemory); }
+	
 private:
-	UPROPERTY()
-	TObjectPtr<ABoss> Boss;
-
-	UPROPERTY()
-	TObjectPtr<AEnhancedBossAIController> AIController;
-
-	UPROPERTY()
-	float AccumulatedTime;
-
-	UPROPERTY()
-	float IdleFinishTime;
-
 	UPROPERTY(EditAnywhere)
 	float IdleFinishMinInterval;
 

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_MoveToLocation.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_MoveToLocation.cpp
@@ -45,7 +45,6 @@ EBTNodeResult::Type UBTTask_MoveToLocation::ExecuteTask(UBehaviorTreeComponent& 
 
 	// 감속을 멈추고 이동 상태로 전이하여 ABP에서 이동 상태임을 인지
 	Boss->SetBossState(EBossState::Move);
-	Boss->SetDecelerate(false);
 	
 	// Task에 할당된 블랙보드 키 값을 추출
 	const FName KeyName = GetSelectedBlackboardKey();
@@ -54,9 +53,6 @@ EBTNodeResult::Type UBTTask_MoveToLocation::ExecuteTask(UBehaviorTreeComponent& 
 	// MoveTask를 종료할 랜덤 시간 추출
 	FinishTaskInterval = FMath::RandRange(MinFinishTaskInterval, MaxFinishTaskInterval);
 	AccumulatedTime = 0.f;
-	
-	// 디버그용 구체 출력 (5초 동안, 반지름 50, 빨간색)
-	//DrawDebugSphere(GetWorld(), TargetLocation, 250.0f, 12, FColor::Red, false, 5.0f);
 
 	const EPathFollowingRequestResult::Type Result = AIController->MoveToLocationWithRadius(TargetLocation);
 	
@@ -94,6 +90,9 @@ void UBTTask_MoveToLocation::TickTask(UBehaviorTreeComponent& Comp, uint8* NodeM
 {
 	Super::TickTask(Comp, NodeMemory, DeltaSeconds);
 
+	// 디버그용 구체 출력 (5초 동안, 반지름 50, 빨간색)
+	DrawDebugSphere(GetWorld(), TargetLocation, 250.0f, 12, FColor::Green, false, 0.1f);
+	
 	// 감속 거리에 도달한 경우 감속 트리거
 	const float Distance = FVector::Dist(Boss->GetActorLocation(), TargetLocation);
 	if (Distance < DecelerationTriggeredRadius)

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_MoveToLocation.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_MoveToLocation.h
@@ -5,6 +5,33 @@
 #include "Boss/EnhancedBossAIController.h"
 #include "BTTask_MoveToLocation.generated.h"
 
+struct FBTMoveToLocationTaskMemory
+{
+	/** 빙의한 AIController에 대한 참조 */
+	TWeakObjectPtr<AEnhancedBossAIController> AIController;
+
+	/** AIController의 주체에 대한 참조 */
+	TWeakObjectPtr<ABoss> Boss;
+
+	/** 현재까지 경과된 시간 */
+	float AccumulatedTime;
+
+	/** 작업이 끝나는 시간 */
+	float FinishTaskInterval;
+
+	/** 이동해야하는 위치 */
+	FVector TargetLocation;
+
+	/** 이동에 방해받았을 때 차선으로 이동해야하는 위치 */
+	FVector CachedLocation;
+
+	/** 이전 이동 좌표와 현재 이동 좌표의 오차를 확인하기 위한 상태 변수 */
+	uint8 bHasBeenTriggeredMoveToLocation : 1;
+
+	/** 이동에 방해받았을 때 활성화함으로써 차선위치로 이동하기 위한 상태 변수 */
+	uint8 bShouldMoveToNearestPoint : 1;
+};
+
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API UBTTask_MoveToLocation : public UBTTask_BlackboardBase
 {
@@ -17,32 +44,9 @@ private:
 	virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory) override;
 	virtual void TickTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory, float DeltaSeconds) override;
 	virtual void OnTaskFinished(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, EBTNodeResult::Type TaskResult) override;
-
+	virtual uint16 GetInstanceMemorySize() const override { return sizeof(FBTMoveToLocationTaskMemory); };
+	
 private:
-	UPROPERTY()
-	TObjectPtr<ABoss> Boss;
-
-	UPROPERTY()
-	TObjectPtr<AEnhancedBossAIController> AIController;
-
-	UPROPERTY()
-	FVector TargetLocation;
-
-	UPROPERTY()
-	FVector CachedLocation;
-
-	UPROPERTY()
-	uint8 bHasBeenTriggeredMoveToLocation : 1;
-
-	UPROPERTY()
-	uint8 bShouldMoveToNearestPoint : 1;
-
-	UPROPERTY()
-	float AccumulatedTime;
-
-	UPROPERTY()
-	float FinishTaskInterval;
-
 	UPROPERTY(EditAnywhere)
 	float MinFinishTaskInterval;
 

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_PlayerChase.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_PlayerChase.cpp
@@ -28,7 +28,6 @@ EBTNodeResult::Type UBTTask_PlayerChase::ExecuteTask(UBehaviorTreeComponent& Com
 	if (!IsValid(Boss)) return EBTNodeResult::Failed;
 
 	Boss->SetBossState(EBossState::Chase);
-	Boss->SetDecelerate(false);
 	
 	// 랜덤 시간 추출
 	AccumulatedTime = 0.f;
@@ -40,6 +39,16 @@ EBTNodeResult::Type UBTTask_PlayerChase::ExecuteTask(UBehaviorTreeComponent& Com
 void UBTTask_PlayerChase::TickTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory, float DeltaSeconds)
 {
 	Super::TickTask(Comp, NodeMemory, DeltaSeconds);
+
+	// 추적 중인 플레이어가 사망 상태인 경우 상태 초기화
+	if (IsValid(Boss->GetTarget()))
+	{
+		if (Boss->GetTarget()->GetCharacterState() == ECharacterState::Death)
+		{
+			AIController->InitVariables();
+			return;
+		}
+	}
 
 	// 추적하는 타겟 방향으로 보스 이동
 	AIController->MoveToActorWithRadius();

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_PlayerChase.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_PlayerChase.h
@@ -5,6 +5,21 @@
 #include "Boss/EnhancedBossAIController.h"
 #include "BTTask_PlayerChase.generated.h"
 
+struct FBTPlayerChaseTaskMemory
+{
+	/** 빙의한 AIController에 대한 참조 */
+	TWeakObjectPtr<AEnhancedBossAIController> AIController;
+
+	/** AIController의 주체에 대한 참조 */
+	TWeakObjectPtr<ABoss> Boss;
+
+	/** 현재까지 경과된 시간 */
+	float AccumulatedTime;
+
+	/** Chase 작업이 끝나는 시간 */
+	float FinishTaskInterval;
+};
+
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API UBTTask_PlayerChase : public UBTTask_BlackboardBase
 {
@@ -16,14 +31,9 @@ public:
 private:
 	virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory) override;
 	virtual void TickTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory, float DeltaSeconds) override;
+	virtual uint16 GetInstanceMemorySize() const override { return sizeof(FBTPlayerChaseTaskMemory); }
 
 private:
-	UPROPERTY()
-	TObjectPtr<ABoss> Boss;
-
-	UPROPERTY()
-	TObjectPtr<AEnhancedBossAIController> AIController;
-
 	UPROPERTY(EditAnywhere)
 	float MoveSpeedMultiplier = 1.3f;
 
@@ -32,12 +42,6 @@ private:
 
 	UPROPERTY(EditAnywhere)
 	float MinChaseTime;
-
-	UPROPERTY()
-	float AccumulatedTime;
-
-	UPROPERTY()
-	float TimeCriteria;
 
 	static const FName bIsPlayerHiddenKey;
 };

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_PlayerDetected.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_PlayerDetected.cpp
@@ -34,7 +34,6 @@ EBTNodeResult::Type UBTTask_PlayerDetected::ExecuteTask(UBehaviorTreeComponent& 
 	if (!IsValid(Boss)) return EBTNodeResult::Failed;
 	
 	Boss->SetBossState(EBossState::Idle);
-	Boss->SetDecelerate(true);
 	
 	AccumulatedTime = 0;
 	

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_PlayerDetected.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_PlayerDetected.cpp
@@ -19,23 +19,24 @@ UBTTask_PlayerDetected::UBTTask_PlayerDetected()
 	NodeName = "Player Detected";
 	bNotifyTick = true;
 	bNotifyTaskFinished = true;
-	Boss = nullptr;
-	AIController = nullptr;
-	AccumulatedTime = 0;
+	bCreateNodeInstance = false;
+
 	DetectedStateInterval = 2.f;
 }
 
 EBTNodeResult::Type UBTTask_PlayerDetected::ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory)
 {
-	AIController = Cast<AEnhancedBossAIController>(Comp.GetAIOwner());
-	if (!IsValid(AIController)) return EBTNodeResult::Failed;
+	FBTPlayerDetectedTaskMemory* TaskMemory = (FBTPlayerDetectedTaskMemory*)NodeMemory;
+	if (!TaskMemory) return EBTNodeResult::Failed;
 
-	Boss = Cast<ABoss>(AIController->GetCharacter());
-	if (!IsValid(Boss)) return EBTNodeResult::Failed;
+	TaskMemory->AIController = Cast<AEnhancedBossAIController>(Comp.GetAIOwner());
+	TaskMemory->Boss = Cast<ABoss>(TaskMemory->AIController->GetCharacter());
 	
-	Boss->SetBossState(EBossState::Idle);
+	if (!TaskMemory->Boss.IsValid() || !TaskMemory->AIController.IsValid()) return EBTNodeResult::Failed;
 	
-	AccumulatedTime = 0;
+	TaskMemory->Boss->SetBossState(EBossState::Idle);
+	
+	TaskMemory->AccumulatedTime = 0.f;
 	
 	return EBTNodeResult::InProgress;
 }
@@ -44,19 +45,27 @@ void UBTTask_PlayerDetected::TickTask(UBehaviorTreeComponent& Comp, uint8* NodeM
 {
 	Super::TickTask(Comp, NodeMemory, DeltaSeconds);
 	
-	Boss->RotationToTarget(Boss->GetTarget());
+	FBTPlayerDetectedTaskMemory* TaskMemory = (FBTPlayerDetectedTaskMemory*)NodeMemory;
+	if (!TaskMemory) return;
 
-	if (AIController->GetIsDisappearPlayer())
+	TaskMemory->AIController = Cast<AEnhancedBossAIController>(Comp.GetAIOwner());
+	TaskMemory->Boss = Cast<ABoss>(TaskMemory->AIController->GetCharacter());
+	
+	if (!TaskMemory->Boss.IsValid() || !TaskMemory->AIController.IsValid()) return;
+	
+	TaskMemory->Boss->RotationToTarget(TaskMemory->Boss->GetTarget());
+
+	if (TaskMemory->AIController->GetIsDisappearPlayer())
 	{
 		FinishLatentTask(Comp, EBTNodeResult::Succeeded);
 	}
 
-	if (AccumulatedTime > DetectedStateInterval)
+	if (TaskMemory->AccumulatedTime > DetectedStateInterval)
 	{
 		FinishLatentTask(Comp, EBTNodeResult::Succeeded);
 	}
 
-	AccumulatedTime += FMath::Clamp(DeltaSeconds, 0.f, 0.1f);
+	TaskMemory->AccumulatedTime += FMath::Clamp(DeltaSeconds, 0.f, 0.1f);
 }
 
 void UBTTask_PlayerDetected::OnTaskFinished(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory,
@@ -64,5 +73,13 @@ void UBTTask_PlayerDetected::OnTaskFinished(UBehaviorTreeComponent& OwnerComp, u
 {
 	Super::OnTaskFinished(OwnerComp, NodeMemory, TaskResult);
 
-	AIController->GetBlackboardComponent()->SetValueAsBool("bHasDetectedPlayer", true);
+	FBTPlayerDetectedTaskMemory* TaskMemory = (FBTPlayerDetectedTaskMemory*)NodeMemory;
+	if (!TaskMemory) return;
+
+	TaskMemory->AIController = Cast<AEnhancedBossAIController>(OwnerComp.GetAIOwner());
+	TaskMemory->Boss = Cast<ABoss>(TaskMemory->AIController->GetCharacter());
+	
+	if (!TaskMemory->Boss.IsValid() || !TaskMemory->AIController.IsValid()) return;
+	
+	TaskMemory->AIController->GetBlackboardComponent()->SetValueAsBool("bHasDetectedPlayer", true);
 }

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_PlayerDetected.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_PlayerDetected.h
@@ -5,6 +5,18 @@
 #include "Boss/EnhancedBossAIController.h"
 #include "BTTask_PlayerDetected.generated.h"
 
+struct FBTPlayerDetectedTaskMemory
+{
+	/** 빙의한 AIController에 대한 참조 */
+	TWeakObjectPtr<AEnhancedBossAIController> AIController;
+
+	/** AIController의 주체에 대한 참조 */
+	TWeakObjectPtr<ABoss> Boss;
+
+	/** 현재까지 경과된 시간 */
+	float AccumulatedTime;
+};
+
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API UBTTask_PlayerDetected : public UBTTask_BlackboardBase
 {
@@ -17,17 +29,9 @@ private:
 	virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory) override;
 	virtual void TickTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory, float DeltaSeconds) override;
 	virtual void OnTaskFinished(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, EBTNodeResult::Type TaskResult) override;
-
-private:
-	UPROPERTY()
-	TObjectPtr<ABoss> Boss;
-
-	UPROPERTY()
-	TObjectPtr<AEnhancedBossAIController> AIController;
-
-	UPROPERTY()
-	float AccumulatedTime;
+	virtual uint16 GetInstanceMemorySize() const override { return sizeof(FBTPlayerDetectedTaskMemory); }
 	
+private:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (AllowPrivateAccess = true))
 	float DetectedStateInterval;
 	

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_SetMovePointAroundMonster.cpp
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_SetMovePointAroundMonster.cpp
@@ -15,10 +15,10 @@ UBTTask_SetMovePointAroundMonster::UBTTask_SetMovePointAroundMonster()
 
 EBTNodeResult::Type UBTTask_SetMovePointAroundMonster::ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory)
 {
-	AIController = Cast<AEnhancedBossAIController>(Comp.GetAIOwner());
+	AEnhancedBossAIController* AIController = Cast<AEnhancedBossAIController>(Comp.GetAIOwner());
 	if (!IsValid(AIController)) return EBTNodeResult::Failed;
 	
-	Boss = Cast<ABoss>(AIController->GetCharacter());
+	ABoss* Boss = Cast<ABoss>(AIController->GetCharacter());
 	if (!IsValid(Boss)) return EBTNodeResult::Failed;
 
 	const FName BlackboardKeyName = GetSelectedBlackboardKey();

--- a/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_SetMovePointAroundMonster.h
+++ b/Source/AbyssDiverUnderWorld/Boss/Task/Enhanced/BTTask_SetMovePointAroundMonster.h
@@ -16,11 +16,4 @@ public:
 private:
 	virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& Comp, uint8* NodeMemory) override;
 
-private:
-	UPROPERTY()
-	TObjectPtr<ABoss> Boss;
-
-	UPROPERTY()
-	TObjectPtr<AEnhancedBossAIController> AIController;
-	
 };


### PR DESCRIPTION
---

## 📝 작업 상세 내용
<!-- 어떤 기능을 추가/수정했는지 상세히 기술해주세요 -->
### 문제 상황
- Behavior Tree 노드가 AI 별로 인스턴스화 되는 것이 아닌 공유함 
-> Task 내에 선언한 변수를 AI가 공유 
-> 특정 AI가 공격 상태가 되면 다른 AI가 먹통이 되거나 따라서 공격 상태가 됨

### 해결 방법
- 노드 자체를 Instance화 시키거나 노드의 메모리 데이터만 Instance화 시키면 해결할 수 있음
- 노드 자체를 Instance화 하는 것은 구현 비용은 굉장히 낮지만, 메모리적으로 비효율성 유발
- 따라서 구현 비용이 높더라도 메모리 데이터를 Instance화 하는 방법 채택

---

## 📸 스크린샷 (선택)
<!-- UI, 이펙트, 레벨 디자인 등 시각적 작업 시 스크린샷 첨부 -->
![image](https://github.com/user-attachments/assets/b21e0420-771f-4574-90f7-dd4cb8e4c088)

![image](https://github.com/user-attachments/assets/0ccf3885-c990-42e2-b0be-8f6bafbd88f1)

---

## 🙋 리뷰어에게 요청사항
<!-- 리뷰 시 중점적으로 봐줬으면 하는 부분 -->

---
