### PR TITLE
선택한 미션 UI에 표시 및 UI 동기화 완료 및 기타

### DIFF
--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameState.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameState.h
@@ -1,4 +1,4 @@
-#pragma once
+Ôªø#pragma once
 
 #include "CoreMinimal.h"
 #include "GameFramework/GameState.h"
@@ -15,6 +15,9 @@ class AADDroneSeller;
 struct FActivatedMissionInfoList;
 
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnGameStatePropertyChangedDelegate, int32 /*Changed Value*/);
+DECLARE_MULTICAST_DELEGATE_TwoParams(FOnMissionInfosChangedDelegate, int32 /*Changed Index*/, const FActivatedMissionInfoList& /*Changed Value*/);
+DECLARE_MULTICAST_DELEGATE_TwoParams(FOnMissionInfosRemovedDelegate, int32 /*Changed Index*/, const FActivatedMissionInfoList& /*Changed Value*/);
+DECLARE_MULTICAST_DELEGATE(FOnMissionListRefreshedDelegate);
 
 #pragma region FastArraySerializer
 
@@ -61,11 +64,14 @@ public:
 	void ModifyProgress(const EMissionType& MissionType, const uint8& MissionIndex, const uint8& NewProgress);
 	void AddOrModify(const EMissionType& MissionType, const uint8& MissionIndex, const uint8& NewProgress);
 
-	//// ¿Œµ¶Ω∫ π›»Ø, æ¯¿∏∏È INDEX_NONE π›»Ø
+	// Ïù∏Îç±Ïä§ Î∞òÌôò, ÏóÜÏúºÎ©¥ INDEX_NONE Î∞òÌôò
 	int32 Contains(const EMissionType& MissionType, const uint8& MissionIndex);
 	
 	void Clear(const int32 SlackCount = 0);
 
+	FOnMissionInfosChangedDelegate OnMissionInfosChangedDelegate;
+	FOnMissionInfosRemovedDelegate OnMissionInfosRemovedDelegate;
+	
 public:
 
 	UPROPERTY()
@@ -91,16 +97,22 @@ class ABYSSDIVERUNDERWORLD_API AADInGameState : public AGameState
 public:
 	AADInGameState();
 
-#pragma region Method
-public:
+protected:
+
 	virtual void PostInitializeComponents() override;
+
 	virtual void BeginPlay() override;
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 	virtual void PostNetInit() override;
 
-	UFUNCTION(BlueprintCallable, Exec)
+#pragma region Method
+
+public:
+
+	UFUNCTION(BlueprintCallable)
 	void AddTeamCredit(int32 Credit);
-	UFUNCTION(BlueprintCallable, Exec)
+
+	UFUNCTION(BlueprintCallable)
 	void IncrementPhase();
 
 	UFUNCTION(BlueprintCallable)
@@ -108,9 +120,12 @@ public:
 
 	FString GetMapDisplayName() const;
 
+	void RefreshActivatedMissionList();
+
 	FOnGameStatePropertyChangedDelegate TeamCreditsChangedDelegate;
 	FOnGameStatePropertyChangedDelegate CurrentPhaseChangedDelegate;
 	FOnGameStatePropertyChangedDelegate CurrentPhaseGoalChangedDelegate;
+	FOnMissionListRefreshedDelegate OnMissionListRefreshedDelegate;
 
 protected:
 
@@ -219,6 +234,8 @@ public:
 		CurrentDroneSeller = NewDroneSeller;
 		OnRep_CurrentDroneSeller();
 	}
+
+	FActivatedMissionInfoList& GetActivatedMissionList() { return ActivatedMissionList; }
 
 #pragma endregion
 

--- a/Source/AbyssDiverUnderWorld/Framework/ADPlayerState.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADPlayerState.h
@@ -23,16 +23,11 @@ protected:
     virtual void BeginPlay() override;
     virtual void PostNetInit() override;
 
-#pragma region Method
-public:
-    // 미션 관련 함수
-    const TArray<FMissionData>& GetSelectedMissions() const { return SelectedMissions; }
-    void SetSelectedMissions(const TArray<FMissionData>& NewMissions) { SelectedMissions = NewMissions; }
-#pragma endregion
-
-
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 	virtual void CopyProperties(APlayerState* PlayerState) override;
+
+#pragma region Method
+
 public:
 	void SetPlayerInfo(const FString& InNickname);
 
@@ -43,13 +38,10 @@ public:
 	UFUNCTION()
 	void OnRep_Nickname();
 
+#pragma endregion
 
 #pragma region Variable
 protected:
-
-    // 선택된 미션 목록
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mission")
-    TArray<FMissionData> SelectedMissions;
 
 	// persistent Data
 	UPROPERTY(Replicated)

--- a/Source/AbyssDiverUnderWorld/Subsystems/MissionSubsystem.h
+++ b/Source/AbyssDiverUnderWorld/Subsystems/MissionSubsystem.h
@@ -19,6 +19,7 @@ class UItemUseMission;
 class UKillMonsterMission;
 class UMissionBase;
 
+class AADInGameState;
 /**
  * 
  */
@@ -72,6 +73,8 @@ private:
 
 	void UnlockMissionInternal(FMissionBaseRow* MissionsFromUI);
 
+	bool CheckIfGameStateIsValid();
+
 #pragma endregion
 
 #pragma region Variables
@@ -100,6 +103,8 @@ private:
 	int32 ItemCollectMissionCount = 0;
 	int32 ItemUseMissionCount = 0;
 	int32 KillMonsterMissionCount = 0;
+
+	TObjectPtr<AADInGameState> InGameState;
 
 #pragma endregion
 

--- a/Source/AbyssDiverUnderWorld/Subsystems/SoundSubsystem.cpp
+++ b/Source/AbyssDiverUnderWorld/Subsystems/SoundSubsystem.cpp
@@ -409,23 +409,31 @@ UAudioComponent* USoundSubsystem::GetNewAudio()
 {
 	TObjectPtr<UAudioComponent> NewAudio = nullptr;
 
-	while (true)
+	static const int32 SafetyLimit = 100;
+	int32 Iteration = 0;
+	for (; Iteration < SafetyLimit; ++Iteration)
 	{
 		if (DeactivatedComponents.IsEmpty())
 		{
 			CreateAudioComponent();
 		}
 
-		DeactivatedComponents.Peek(NewAudio);
+		DeactivatedComponents.Dequeue(NewAudio);
 
 		if (NewAudio == nullptr || IsValid(NewAudio) == false || NewAudio->IsValidLowLevel() == false)
 		{
 			LOGV(Error, TEXT("Not Valid"));
 			continue;
 		}
+		else
+		{
+			break;
+		}
+	}
 
-		DeactivatedComponents.Pop();
-		break;
+	if (Iteration >= SafetyLimit)
+	{
+		LOGV(Error, TEXT("Fail to Get New Audio"));
 	}
 
 	return NewAudio;

--- a/Source/AbyssDiverUnderWorld/UI/MissionSelectWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/UI/MissionSelectWidget.cpp
@@ -106,34 +106,10 @@ void UMissionSelectWidget::OnStartButtonClicked()
 
     if (APlayerController* PC = GetOwningPlayer())
     {
-        if (AADPlayerState* PS = PC->GetPlayerState<AADPlayerState>())
-        {
-            PS->SetSelectedMissions(SelectedMissions);
-            UE_LOG(LogTemp, Warning, TEXT("✅ [MissionSelectWidget] 선택된 미션 수: %d"), SelectedMissions.Num());
-        }
-
+        UE_LOG(LogTemp, Warning, TEXT("✅ [MissionSelectWidget] 선택된 미션 수: %d"), SelectedMissions.Num());
         // 입력 모드 원복
         FInputModeGameOnly InputMode;
         PC->SetInputMode(InputMode);
         PC->bShowMouseCursor = false;
-
-        // ✅ 미션 리스트 위젯 생성 및 화면에 추가
-        if (WBP_SelectedMissionListClass) // UPROPERTY로 받은 위젯 클래스
-        {
-            USelectedMissionListWidget* MissionListWidget = CreateWidget<USelectedMissionListWidget>(GetWorld(), WBP_SelectedMissionListClass);
-            if (MissionListWidget)
-            {
-                MissionListWidget->AddToViewport();
-                UE_LOG(LogTemp, Warning, TEXT("✅ 선택된 미션 리스트 위젯 AddToViewport 완료"));
-            }
-            else
-            {
-                UE_LOG(LogTemp, Error, TEXT("❌ 선택된 미션 리스트 위젯 생성 실패"));
-            }
-        }
-        else
-        {
-            UE_LOG(LogTemp, Error, TEXT("❌ WBP_SelectedMissionListClass가 설정되지 않음"));
-        }
     }
 }

--- a/Source/AbyssDiverUnderWorld/UI/MissionSelectWidget.h
+++ b/Source/AbyssDiverUnderWorld/UI/MissionSelectWidget.h
@@ -51,7 +51,6 @@ protected:
     UPROPERTY(EditDefaultsOnly, Category = "UI")
     TSubclassOf<USelectedMissionListWidget> WBP_SelectedMissionListClass;
 
-
 private:
     // 미션 데이터
     TArray<FMissionData> AllMissions;

--- a/Source/AbyssDiverUnderWorld/UI/SelectedMissionListWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/UI/SelectedMissionListWidget.cpp
@@ -1,7 +1,12 @@
 #include "UI/SelectedMissionListWidget.h"
+
+#include "AbyssDiverUnderWorld.h"
+#include "Framework/ADPlayerState.h"
+#include "Framework/ADInGameState.h"
+#include "Subsystems/MissionSubsystem.h"
+
 #include "Components/VerticalBox.h"
 #include "Components/TextBlock.h"
-#include "Framework/ADPlayerState.h"
 #include "Kismet/GameplayStatics.h"
 
 void USelectedMissionListWidget::NativeConstruct()
@@ -14,30 +19,105 @@ void USelectedMissionListWidget::NativeConstruct()
         return;
     }
 
+    Refresh();
+}
+
+void USelectedMissionListWidget::AddElement(const FString& ElementText)
+{
+    UTextBlock* MissionText = NewObject<UTextBlock>(this);
+    MissionText->SetText(FText::FromString(ElementText));
+    MissionText->SetFont(FSlateFontInfo(FCoreStyle::GetDefaultFontStyle("Bold", 24)));
+    MissionText->SetColorAndOpacity(FSlateColor(FLinearColor::White));
+
+    VerticalBox_MissionList->AddChildToVerticalBox(MissionText);
+    LOGV(Warning, TEXT("%s"), *ElementText);
+}
+
+void USelectedMissionListWidget::RemoveElementAt(const int32& Index)
+{
+    VerticalBox_MissionList->RemoveChildAt(Index);
+}
+
+void USelectedMissionListWidget::ModifyElementAt(const FString& NewText, const int32& Index)
+{
+    UTextBlock* Element = CastChecked<UTextBlock>(VerticalBox_MissionList->GetChildAt(Index));
+
+    Element->SetText(FText::FromString(NewText));
+    LOGV(Warning, TEXT("%s"), *NewText);
+}
+
+void USelectedMissionListWidget::AddOrModifyElement(int32 ChangedIndex, const FActivatedMissionInfoList& ChangedValue)
+{
+    UMissionSubsystem* MissionSubsystem = GetGameInstance()->GetSubsystem<UMissionSubsystem>();
+    if (MissionSubsystem == nullptr)
+    {
+        LOGV(Warning, TEXT("MissionSubsystem == nullptr"));
+        return;
+    }
+
+    EMissionType MissionType = ChangedValue.MissionInfoList[ChangedIndex].MissionType;
+    uint8 MissionIndex = ChangedValue.MissionInfoList[ChangedIndex].MissionIndex;
+    FString NewElementText = "";
+
+    switch (MissionType)
+    {
+    case EMissionType::AggroTrigger:
+        NewElementText = MissionSubsystem->GetAggroTriggerMissionData((EAggroTriggerMission)MissionIndex)->MissionName;
+        break;
+    case EMissionType::Interaction:
+        NewElementText = MissionSubsystem->GetInteractionMissionData((EInteractionMission)MissionIndex)->MissionName;
+        break;
+    case EMissionType::ItemCollection:
+        NewElementText = MissionSubsystem->GetItemCollectMissionData((EItemCollectMission)MissionIndex)->MissionName;
+        break;
+    case EMissionType::ItemUse:
+        NewElementText = MissionSubsystem->GetItemUseMissionData((EItemUseMission)MissionIndex)->MissionName;
+        break;
+    case EMissionType::KillMonster:
+        NewElementText = MissionSubsystem->GetKillMonsterMissionData((EKillMonsterMission)MissionIndex)->MissionName;
+        break;
+    default:
+        check(false);
+        return;
+    }
+
+    if (VerticalBox_MissionList->GetChildAt(ChangedIndex))
+    {
+        ModifyElementAt(NewElementText, ChangedIndex);
+    }
+    else
+    {
+        AddElement(NewElementText);
+    }
+}
+
+void USelectedMissionListWidget::Refresh()
+{
+    AADInGameState* GS = Cast<AADInGameState>(UGameplayStatics::GetGameState(GetWorld()));
+    if (GS == nullptr)
+    {
+        LOGV(Warning, TEXT("GS == nullptr"));
+        return;
+    }
+
+    FActivatedMissionInfoList& MissionList = GS->GetActivatedMissionList();
+
+    const TArray<FActivatedMissionInfo>& MissionInfos = MissionList.MissionInfoList;
     VerticalBox_MissionList->ClearChildren();
 
-    // PlayerState에서 미션 가져오기
-    if (APlayerController* PC = UGameplayStatics::GetPlayerController(this, 0))
+    for (int32 i = 0; i < MissionInfos.Num(); ++i)
     {
-        if (AADPlayerState* PS = PC->GetPlayerState<AADPlayerState>())
-        {
-            const TArray<FMissionData>& Missions = PS->GetSelectedMissions();
+        AddOrModifyElement(i, MissionList);
+    }
 
-            for (const FMissionData& Mission : Missions)
-            {
-                UTextBlock* MissionText = NewObject<UTextBlock>(this, UTextBlock::StaticClass());
-                MissionText->SetText(FText::FromString(Mission.Title));
-                MissionText->SetFont(FSlateFontInfo(FCoreStyle::GetDefaultFontStyle("Bold", 24)));
-                MissionText->SetColorAndOpacity(FSlateColor(FLinearColor::White));
-
-                VerticalBox_MissionList->AddChildToVerticalBox(MissionText);
-            }
-
-            UE_LOG(LogTemp, Warning, TEXT("✅ WBP_SelectedMissionList에 %d개 미션 표시됨"), Missions.Num());
-        }
-        else
-        {
-            UE_LOG(LogTemp, Error, TEXT("❌ ADPlayerState 캐스팅 실패"));
-        }
+    if (GS->HasAuthority())
+    {
+        GS->OnMissionListRefreshedDelegate.RemoveAll(this);
+        GS->OnMissionListRefreshedDelegate.AddUObject(this, &USelectedMissionListWidget::Refresh);
+    }
+    else
+    {
+        MissionList.OnMissionInfosChangedDelegate.RemoveAll(this);
+        MissionList.OnMissionInfosChangedDelegate.AddUObject(this, &USelectedMissionListWidget::AddOrModifyElement);
     }
 }

--- a/Source/AbyssDiverUnderWorld/UI/SelectedMissionListWidget.h
+++ b/Source/AbyssDiverUnderWorld/UI/SelectedMissionListWidget.h
@@ -7,6 +7,9 @@
 
 class UVerticalBox;
 class UMissionEntryWidget;
+class UTextBlock;
+
+struct FActivatedMissionInfoList;
 
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API USelectedMissionListWidget : public UUserWidget
@@ -16,6 +19,18 @@ class ABYSSDIVERUNDERWORLD_API USelectedMissionListWidget : public UUserWidget
 public:
     // 생성자, 생명주기 함수
     virtual void NativeConstruct() override;
+
+public:
+
+    void AddElement(const FString& ElementText);
+    void RemoveElementAt(const int32& Index);
+    void ModifyElementAt(const FString& NewText, const int32& Index);
+
+    void AddOrModifyElement(int32 ChangedIndex, const FActivatedMissionInfoList& ChangedValue);
+
+private:
+
+    void Refresh();
 
 protected:
 #pragma region Variable


### PR DESCRIPTION

---

## 📝 작업 상세 내용
## 선택된 미션 UI에 표시
### ADInGameState
- 미션용 FastArray에 변화 감지용 델리게이트 추가
- 미션용 FastArray Refresh 함수 생성

### ADPlayerState
- 필요 없다고 판단한 함수, 프로퍼티 삭제 : GetSelectedMissions, SetSelectedMissions, SelectedMissions

### MissionSubsystem
- 미션이 선택되고 만들어진 후 UI Refresh

### MissionSelectWidget
- PlayerState를 활용한 로직 삭제 - MissionSubsystem에서 담당하므로

### SelectedMisionListWidget
- PlayerState를 활용한 로직 삭제 - MissionSubsystem에서 담당하므로
- Refresh 함수 : 미션 UI 리스트 갱신 및 델리게이트 바인딩

## 기타
- SoundSubsystem : while 무한 반복문 대신 안전 장치 추가 - 최대 100회까지만 반복하도록

---
