### PR TITLE
🐛 bugfix 스포너들 버그 해결 및 기타

### DIFF
--- a/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Monster/MonsterSpawner.cpp
+++ b/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Monster/MonsterSpawner.cpp
@@ -10,12 +10,36 @@ AMonsterSpawner::AMonsterSpawner()
 	MaxMonsterSpawnCount = 10;
 }
 
+void AMonsterSpawner::PostInitializeComponents()
+{
+	Super::PostInitializeComponents();
+
+#if WITH_EDITOR
+
+	// 게임 중이 아닌 경우 리턴(블루프린트 상일 경우)
+	// PostInitializeComponents는 블루프린트에서도 발동함
+	UWorld* World = GetWorld();
+	if (World == nullptr || World->IsGameWorld() == false)
+	{
+		return;
+	}
+
+#endif
+
+	// 호스트만 사용
+	if (HasAuthority() == false)
+	{
+		return;
+	}
+
+	TotalSpawnPoints = GetSpawnPoint(AMonsterSpawnPoint::StaticClass());
+
+	RemoveInValidMonsterClass();
+}
+
 void AMonsterSpawner::BeginPlay()
 {
 	Super::BeginPlay();
-
-	TotalSpawnPoints = GetSpawnPoint(AMonsterSpawnPoint::StaticClass());
-	RemoveInValidMonsterClass();
 }
 
 void AMonsterSpawner::Spawn()

--- a/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Monster/MonsterSpawner.h
+++ b/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Monster/MonsterSpawner.h
@@ -15,6 +15,7 @@ public:
 	AMonsterSpawner();
 
 public:
+	virtual void PostInitializeComponents() override;
 	virtual void BeginPlay() override;
 
 public:

--- a/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Ore/OreSpawner.cpp
+++ b/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Ore/OreSpawner.cpp
@@ -9,11 +9,34 @@ AOreSpawner::AOreSpawner()
 	MaxOreSpawnCount = 10;
 }
 
+void AOreSpawner::PostInitializeComponents()
+{
+	Super::PostInitializeComponents();
+
+#if WITH_EDITOR
+
+	// 게임 중이 아닌 경우 리턴(블루프린트 상일 경우)
+	// PostInitializeComponents는 블루프린트에서도 발동함
+	UWorld* World = GetWorld();
+	if (World == nullptr || World->IsGameWorld() == false)
+	{
+		return;
+	}
+
+#endif
+
+	// 호스트만 사용
+	if (HasAuthority() == false)
+	{
+		return;
+	}
+
+	TotalSpawnPoints = GetSpawnPoint(AOreSpawnPoint::StaticClass());
+}
+
 void AOreSpawner::BeginPlay()
 {
 	Super::BeginPlay();
-
-	TotalSpawnPoints = GetSpawnPoint(AOreSpawnPoint::StaticClass());
 }
 
 void AOreSpawner::Spawn()

--- a/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Ore/OreSpawner.h
+++ b/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Ore/OreSpawner.h
@@ -15,6 +15,7 @@ public:
 	AOreSpawner();
 
 public:
+	virtual void PostInitializeComponents() override;
 	virtual void BeginPlay() override;
 
 public:

--- a/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Serpmare/SerpmareSpawner.cpp
+++ b/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Serpmare/SerpmareSpawner.cpp
@@ -25,12 +25,35 @@ ASerpmareSpawner::ASerpmareSpawner()
 	BigSerpmareGroup.MaxSerpmareSpawnCount = 3;
 }
 
-void ASerpmareSpawner::BeginPlay()
+void ASerpmareSpawner::PostInitializeComponents()
 {
-	Super::BeginPlay();
+	Super::PostInitializeComponents();
+
+#if WITH_EDITOR
+
+	// 게임 중이 아닌 경우 리턴(블루프린트 상일 경우)
+	// PostInitializeComponents는 블루프린트에서도 발동함
+	UWorld* World = GetWorld();
+	if (World == nullptr || World->IsGameWorld() == false)
+	{
+		return;
+	}
+
+#endif
+
+	// 호스트만 사용
+	if (HasAuthority() == false)
+	{
+		return;
+	}
 
 	MiniSerpmareGroup.SerpmareSpawnPoints = GetSpawnPoint(AMiniSerpmareSpawnPoint::StaticClass());
 	BigSerpmareGroup.SerpmareSpawnPoints = GetSpawnPoint(ABigSerpmareSpawnPoint::StaticClass());
+}
+
+void ASerpmareSpawner::BeginPlay()
+{
+	Super::BeginPlay();
 }
 
 void ASerpmareSpawner::Spawn()

--- a/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Serpmare/SerpmareSpawner.h
+++ b/Source/AbyssDiverUnderWorld/Gimmic/Spawn/Spawner/Serpmare/SerpmareSpawner.h
@@ -40,6 +40,7 @@ public:
 	ASerpmareSpawner();
 
 public:
+	virtual void PostInitializeComponents() override;
 	virtual void BeginPlay() override;
 
 public:

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/EventTriggers/EventTrigger.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/EventTriggers/EventTrigger.cpp
@@ -1,4 +1,4 @@
-#include "Interactable/OtherActors/EventTriggers/EventTrigger.h"
+ï»¿#include "Interactable/OtherActors/EventTriggers/EventTrigger.h"
 
 #include "AbyssDiverUnderWorld.h"
 
@@ -20,10 +20,20 @@ void AEventTrigger::PostInitializeComponents()
 {
 	Super::PostInitializeComponents();
 
-	// °ÔÀÓ ÁßÀÌ ¾Æ´Ñ °æ¿ì ¸®ÅÏ(ºí·çÇÁ¸°Æ® »óÀÏ °æ¿ì)
-	// PostInitializeComponents´Â ºí·çÇÁ¸°Æ®¿¡¼­µµ ¹ßµ¿ÇÔ
+#if WITH_EDITOR
+
+	// ê²Œìž„ ì¤‘ì´ ì•„ë‹Œ ê²½ìš° ë¦¬í„´(ë¸”ë£¨í”„ë¦°íŠ¸ ìƒì¼ ê²½ìš°)
+	// PostInitializeComponentsëŠ” ë¸”ë£¨í”„ë¦°íŠ¸ì—ì„œë„ ë°œë™í•¨
 	UWorld* World = GetWorld();
 	if (World == nullptr || World->IsGameWorld() == false)
+	{
+		return;
+	}
+
+#endif
+
+	// í˜¸ìŠ¤íŠ¸ë§Œ ì‚¬ìš©
+	if (HasAuthority() == false)
 	{
 		return;
 	}

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/MissionSelectors/MissionSelector.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/MissionSelectors/MissionSelector.cpp
@@ -16,6 +16,8 @@ void AMissionSelector::PostInitializeComponents()
 {
 	Super::PostInitializeComponents();
 
+#if WITH_EDITOR
+
 	// 게임 중이 아닌 경우 리턴(블루프린트 상일 경우)
 	// PostInitializeComponents는 블루프린트에서도 발동함
 	UWorld* World = GetWorld();
@@ -23,6 +25,8 @@ void AMissionSelector::PostInitializeComponents()
 	{
 		return;
 	}
+
+#endif
 
 	// 호스트만 사용
 	if (HasAuthority() == false)

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
@@ -230,6 +230,8 @@ void AShop::PostInitializeComponents()
 {
 	Super::PostInitializeComponents();
 
+#if WITH_EDITOR
+
 	// 게임 중이 아닌 경우 리턴(블루프린트 상일 경우)
 	// PostInitializeComponents는 블루프린트에서도 발동함
 	UWorld* World = GetWorld();
@@ -237,6 +239,8 @@ void AShop::PostInitializeComponents()
 	{
 		return;
 	}
+
+#endif
 
 	InitShopWidget();
 	InitData();


### PR DESCRIPTION


---

## 📝 작업 상세 내용
### 패키징시 첫 번째 스포너 작동하지 않는 버그
- 원인 : SpawnPoint를 찾는 과정과 Spawn하는 순서가 에디터와 반대여서 발생
- 둘다 Beginplay에서 일어났기 때문에 에디터에서는 GetSpawnPoint먼저 일어나고 이후 Spawn을 호출해서 정상이었으나
- 패키징시에는 순서가 반대여서 스폰이 되지 않음.
- 해결 : 더 빠른 시점에 호출되는 PostInitializeComponents로 로직 옮김

### 기타
- PostInitializeComponents에 안전 코드 추가

---
