### PR TITLE
✨ update  페이즈 전부 완료하면 나침반에 잠수정 위치 표시 🎉 add BP_EnterDetectionVolume

### DIFF
--- a/Content/_AbyssDiver/Blueprints/Environmental_Factors/BP_EnterDetectionVolume.uasset
+++ b/Content/_AbyssDiver/Blueprints/Environmental_Factors/BP_EnterDetectionVolume.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5eae620b45d376693cd6ab6537813b4bcae37dff6d648c2569f69b5c1d3257b3
+size 78135

--- a/Content/_AbyssDiver/Blueprints/UI/UI/WBP_PlayerStatusWidget.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/UI/WBP_PlayerStatusWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:882b4e54dbb8e4225ff9932e07ab876612bc72ac69e025bfda892705f9276dd4
-size 244030
+oid sha256:6428b4c1a16bda3c3668f9c95da7fe90483331e8f892a3566e215d44ec5f44f6
+size 272353

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/YWC/TestMap.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/YWC/TestMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1593d393ccd46bcefe84f9cca45a509f6d0d04598e6fdef4590f71418c7ed3da
-size 9876123
+oid sha256:2596b2bca26b1865c8f475452837f0b17c56d38cbf8f3be47df6dc5e503cbf12
+size 9878100

--- a/Source/AbyssDiverUnderWorld/Character/PlayerComponent/PlayerHUDComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/PlayerComponent/PlayerHUDComponent.cpp
@@ -50,6 +50,7 @@ void UPlayerHUDComponent::BeginPlay()
 		if (PlayerStatusWidget)
 		{
 			PlayerStatusWidget->AddToViewport();
+			PlayerStatusWidget->SetCompassObjectWidgetVisible(true);
 		}
 	}
 
@@ -207,6 +208,7 @@ void UPlayerHUDComponent::OnPossessedPawnChanged(APawn* OldPawn, APawn* NewPawn)
 	if (PlayerStatusWidget)
 	{
 		PlayerStatusWidget->AddToViewport();
+		PlayerStatusWidget->SetCompassObjectWidgetVisible(true);
 	}
 
 	if (ResultScreenWidgetClass && IsValid(ResultScreenWidget) == false)

--- a/Source/AbyssDiverUnderWorld/Character/PlayerComponent/PlayerHUDComponent.h
+++ b/Source/AbyssDiverUnderWorld/Character/PlayerComponent/PlayerHUDComponent.h
@@ -69,7 +69,7 @@ private:
     UPROPERTY(EditDefaultsOnly, Category = UI, meta = (AllowPrivateAccess = "true"))
     TSubclassOf<class UPlayerStatusWidget> PlayerStatusWidgetClass;
 
-    UPROPERTY()
+    UPROPERTY(BlueprintReadOnly, meta =(AllowPrivateAccess = true))
     TObjectPtr<UPlayerStatusWidget> PlayerStatusWidget;
     
 #pragma endregion

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.cpp
@@ -82,6 +82,7 @@ void AADInGameMode::BeginPlay()
 			if (DronePhaseNumber == FirstDroneNumber)
 			{
 				InGameState->SetCurrentDroneSeller(Drone->CurrentSeller);
+				InGameState->SetDestinationTarget(Drone->CurrentSeller);
 				Drone->M_PlayPhaseBGM(1);
 			}
 		}

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameState.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameState.h
@@ -141,6 +141,9 @@ protected:
 	UFUNCTION()
 	void OnRep_CurrentDroneSeller();
 
+	UFUNCTION()
+	void OnRep_DestinationTarget();
+
 private:
 
 	void ReceiveDataFromGameInstance();
@@ -168,6 +171,9 @@ protected:
 
 	UPROPERTY(ReplicatedUsing = OnRep_CurrentDroneSeller)
 	TObjectPtr<AADDroneSeller> CurrentDroneSeller;
+
+	UPROPERTY(ReplicatedUsing = OnRep_DestinationTarget)
+	TObjectPtr<AActor> DestinationTarget;
 
 	UPROPERTY(Replicated)
 	FActivatedMissionInfoList ActivatedMissionList;
@@ -235,6 +241,10 @@ public:
 		CurrentDroneSeller = NewDroneSeller;
 		OnRep_CurrentDroneSeller();
 	}
+
+	UFUNCTION(BlueprintPure, Category = "ADInGameState")
+	AActor* GetDestinationTarget() const { return DestinationTarget; }
+	void SetDestinationTarget(AActor* NewDestinationTarget);
 
 	FActivatedMissionInfoList& GetActivatedMissionList() { return ActivatedMissionList; }
 

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/ADDrone.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/ADDrone.cpp
@@ -1,5 +1,6 @@
 ﻿#include "Interactable/OtherActors/ADDrone.h"
 #include "Interactable/Item/Component/ADInteractableComponent.h"
+#include "Interactable/OtherActors/Portals/PortalToSubmarine.h"
 #include "Inventory/ADInventoryComponent.h"
 #include "FrameWork/ADInGameState.h"
 #include "ADDroneSeller.h"
@@ -85,10 +86,12 @@ void AADDrone::Interact_Implementation(AActor* InstigatorActor)
 			{
 				NextSeller->Activate();
 				GS->SetCurrentDroneSeller(NextSeller);
+				GS->SetDestinationTarget(NextSeller);
 			}
 			else
 			{
 				GS->SetCurrentDroneSeller(nullptr);
+				GS->SetDestinationTarget(UGameplayStatics::GetActorOfClass(GetWorld(), APortalToSubmarine::StaticClass()));
 			}
 		}
 	}

--- a/Source/AbyssDiverUnderWorld/UI/PlayerStatusWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/UI/PlayerStatusWidget.cpp
@@ -85,3 +85,8 @@ void UPlayerStatusWidget::SetSpearVisibility(bool bVisible)
         SpearPanel->SetVisibility(bVisible ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
     }
 }
+
+void UPlayerStatusWidget::SetCompassObject(AActor* NewTargetObject)
+{
+    CompassTargetObject = NewTargetObject;
+}

--- a/Source/AbyssDiverUnderWorld/UI/PlayerStatusWidget.h
+++ b/Source/AbyssDiverUnderWorld/UI/PlayerStatusWidget.h
@@ -24,6 +24,10 @@ protected:
 
 #pragma region Method
 public:
+
+	UFUNCTION(BlueprintImplementableEvent, BlueprintCallable, Category = "Compass")
+	void SetCompassObjectWidgetVisible(bool bShouldVisible);
+
 	// 일반 함수
 	void SetSpearCount(int32 Current, int32 Total);
 	void SetOxygenPercent(float InPercent);
@@ -33,6 +37,7 @@ public:
 
 #pragma region Variable
 protected:
+
 	// 작살 수치
 	UPROPERTY()
 	int32 CurrentSpear = 0;
@@ -59,6 +64,9 @@ protected:
 	UPROPERTY(meta = (BindWidget))
 	TObjectPtr<UWidget> SpearPanel;
 
+	UPROPERTY(BlueprintReadOnly, Category = "Compass")
+	TObjectPtr<AActor> CompassTargetObject;
+
 private:
 	UPROPERTY()
 	TArray<TObjectPtr<UImage>> HealthSegments;
@@ -72,5 +80,6 @@ public:
 	void SetCurrentSpear(int32 InValue);
 	void SetTotalSpear(int32 InValue);
 	void SetSpearVisibility(bool bVisible);
+	void SetCompassObject(AActor* NewTargetObject);
 #pragma endregion
 };


### PR DESCRIPTION
---

## 📝 작업 상세 내용
### BP_EnterDetectionVolume
- 잠수정에 들어오면 위젯 끄는 용도

### PlayerStatusWidget
- 나침반의 목표물 위젯 켜고 끄는 기능 추가

### TestMap
- BP_EnterDetectionVolume을 잠수정 내부에 설치

### PlayerHUDComponent
- 레벨이 끝나면 다시 목표물 위젯 보이게 설정
- PlayerStatusWidget BlueprintReadOnly로 변경

### ADInGameMode
- 나침반에 띄울 목적지 타겟을 설정

### ADInGameState
- 목적지 타겟 설정 변수 및 함수

### ADDrone
- 페이즈 넘어걸 때마다 목적지 바꿈

---
