### PR TITLE
[Fix] 랜턴 껐을 때 Patrol로 바로 변경되는 문제 해결, Eject Victim 안움직이던 문제 해결

### DIFF
--- a/Content/_AbyssDiver/Blueprints/Monster/HorrorCreature/BT_HorrorCreature.uasset
+++ b/Content/_AbyssDiver/Blueprints/Monster/HorrorCreature/BT_HorrorCreature.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05b6fc2d4a3844c01af8be239d7b9abcbc45b2fc001e6a78c4a991a905d12406
-size 55669
+oid sha256:fa548e6a9eecb18bb76803ff72593b14d5b3aa9cd53fc3845a6200599259553f
+size 57035

--- a/Source/AbyssDiverUnderWorld/Character/PlayerComponent/LanternComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/PlayerComponent/LanternComponent.cpp
@@ -72,7 +72,7 @@ void ULanternComponent::RequestToggleLanternLight()
 					// Handling Unexposed Monsters
 					if (IsValid(Monster) && Monster->GetMonsterState() == EMonsterState::Investigate)
 					{
-						Monster->SetMonsterState(EMonsterState::Patrol);
+						// Monster->SetMonsterState(EMonsterState::Patrol);
 						Monster->RemoveDetection(GetOwner());
 					}
 					It.RemoveCurrent();
@@ -217,7 +217,7 @@ void ULanternComponent::UpdateExposureTimes(TArray<AActor*> OverlappedActors, co
 			// Handling Unexposed Monsters
 			if (IsValid(Monster) && Monster->GetMonsterState() == EMonsterState::Investigate)
 			{
-				Monster->SetMonsterState(EMonsterState::Patrol);
+				// Monster->SetMonsterState(EMonsterState::Patrol);
 				Monster->RemoveDetection(GetOwner());
 			}
 			It.RemoveCurrent();

--- a/Source/AbyssDiverUnderWorld/Monster/BT/BTTask_InvestigateMoveTo.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/BT/BTTask_InvestigateMoveTo.cpp
@@ -1,0 +1,44 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Monster/BT/BTTask_InvestigateMoveTo.h"
+#include "AIController.h"
+#include "BehaviorTree/BlackboardComponent.h"
+#include "Monster/EMonsterState.h"
+#include "Monster/Monster.h"
+
+UBTTask_InvestigateMoveTo::UBTTask_InvestigateMoveTo()
+{
+	NodeName = "Investigate Move To";
+	bNotifyTick = false;
+	AcceptableRadius = 200.0f;
+}
+
+EBTNodeResult::Type UBTTask_InvestigateMoveTo::ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory)
+{
+	UBlackboardComponent* Blackboard = OwnerComp.GetBlackboardComponent();
+	if (!Blackboard) return EBTNodeResult::Failed;
+	AAIController* AIController = OwnerComp.GetAIOwner();
+	if (!AIController) return EBTNodeResult::Failed;
+	APawn* AIPawn = AIController->GetPawn();
+	if (!AIPawn) return EBTNodeResult::Failed;
+
+	const FVector InvestigateLocation = Blackboard->GetValueAsVector(InvestigateLocationKey.SelectedKeyName);
+	const FVector MonsterLocation = AIPawn->GetActorLocation();
+
+	const float Distance = FVector::Dist(InvestigateLocation, MonsterLocation);
+
+	if (Distance <= AcceptableRadius)
+	{
+		AMonster* Monster = Cast<AMonster>(AIPawn);
+		Blackboard->SetValueAsEnum(MonsterStateKey.SelectedKeyName, static_cast<uint8>(EMonsterState::Patrol));
+
+		if (Monster)
+		{
+			Monster->SetMonsterState(EMonsterState::Patrol); 
+		}
+		return EBTNodeResult::Succeeded;
+	}
+
+	return EBTNodeResult::Failed;
+}

--- a/Source/AbyssDiverUnderWorld/Monster/BT/BTTask_InvestigateMoveTo.h
+++ b/Source/AbyssDiverUnderWorld/Monster/BT/BTTask_InvestigateMoveTo.h
@@ -1,0 +1,29 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BehaviorTree/Tasks/BTTask_BlackboardBase.h"
+#include "BTTask_InvestigateMoveTo.generated.h"
+
+
+UCLASS()
+class ABYSSDIVERUNDERWORLD_API UBTTask_InvestigateMoveTo : public UBTTask_BlackboardBase
+{
+	GENERATED_BODY()
+	
+public:
+	UBTTask_InvestigateMoveTo();
+
+	virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory) override;
+
+protected:
+	UPROPERTY(EditAnywhere, Category = "Blackboard")
+	struct FBlackboardKeySelector MonsterStateKey;
+
+	UPROPERTY(EditAnywhere, Category = "Blackboard")
+	struct FBlackboardKeySelector InvestigateLocationKey;
+
+	UPROPERTY(EditAnywhere)
+	float AcceptableRadius;
+};

--- a/Source/AbyssDiverUnderWorld/Monster/HorrorCreature/HorrorCreature.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/HorrorCreature/HorrorCreature.cpp
@@ -4,6 +4,7 @@
 #include "Monster/HorrorCreature/HorrorCreature.h"
 #include "GameFramework/CharacterMovementComponent.h"
 #include "Character/UnderwaterCharacter.h"
+#include "TimerManager.h"
 
 
 AHorrorCreature::AHorrorCreature()
@@ -84,6 +85,19 @@ void AHorrorCreature::EjectPlayer(AUnderwaterCharacter* Victim)
 	{
 		M_PlayMontage(EjectMontage);
 	}
+
+	GetWorld()->GetTimerManager().SetTimer(
+		TimerHandle_SetSwimMode,
+		[Victim]()
+		{
+			if (IsValid(Victim) && Victim->GetCharacterMovement())
+			{
+				Victim->GetCharacterMovement()->SetMovementMode(MOVE_Swimming);
+			}
+		},
+		0.5f,
+		false
+	);
 
 	SetMonsterState(EMonsterState::Patrol);
 	BlackboardComponent->SetValueAsEnum(MonsterStateKey, static_cast<uint8>(EMonsterState::Patrol));

--- a/Source/AbyssDiverUnderWorld/Monster/HorrorCreature/HorrorCreature.h
+++ b/Source/AbyssDiverUnderWorld/Monster/HorrorCreature/HorrorCreature.h
@@ -48,6 +48,7 @@ protected:
 	UPROPERTY(EditAnywhere)
 	TObjectPtr<UAnimMontage> EjectMontage;
 
+	FTimerHandle TimerHandle_SetSwimMode;
 private:
 	UPROPERTY(EditAnywhere, Category = "Lanch")
 	float LanchStrength;


### PR DESCRIPTION
---

## 📝 작업 상세 내용
[[Fix] 랜턴을 끄거나 DetecteCollision에서 벗어나면 바로 Patrol 되는 문제 해결]
[[Update] 먹히고 나서 뱉었을 때 Player 안움직이던 문제 해결]

---
