### PR TITLE
✨ update 레이더 무시 기능, 나침반 드론 표시 기능 개선, 급류 개선, 🐛 bugfix 패키징 크래시 의심 코드 수정

### DIFF
--- a/Content/_AbyssDiver/Blueprints/Boss/Serpmare/BP_Big_Serpmare.uasset
+++ b/Content/_AbyssDiver/Blueprints/Boss/Serpmare/BP_Big_Serpmare.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86a4849df47f9e71d65f5deb80530b58d22f1ebb383d7f8ef6ac0b44833aaa20
-size 50682
+oid sha256:7f09a04cc17b942c0b19fad43697d67f9cbb8e8c32d9d300c3c6c1afbdc47e32
+size 50665

--- a/Content/_AbyssDiver/Blueprints/UI/UI/WBP_PlayerStatusWidget.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/UI/WBP_PlayerStatusWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6428b4c1a16bda3c3668f9c95da7fe90483331e8f892a3566e215d44ec5f44f6
-size 272353
+oid sha256:d3a9dba554712318f4b8cd15bf137f53472b7f10757cb0c195f6fc46f64353ac
+size 402095

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.cpp
@@ -100,20 +100,23 @@ void AADInGameMode::Logout(AController* Exiting)
 {
 	Super::Logout(Exiting);
 
-	if (ensure(Exiting) == false)
+	if (IsValid(Exiting) == false)
 	{
+		LOGV(Error, TEXT("IsValid(Exiting) == false"));
 		return;
 	}
 
 	AADPlayerState* PS = Exiting->GetPlayerState<AADPlayerState>();
-	if (ensure(PS) == false)
+	if (IsValid(PS) == false)
 	{
+		LOGV(Error, TEXT("IsValid(PS) == false"));
 		return;
 	}
 
 	const FUniqueNetIdRepl& UniqueNetIdRepl = PS->GetUniqueId();
-	if (ensure(&UniqueNetIdRepl) == false)
+	if (UniqueNetIdRepl.IsValid() == false)
 	{
+		LOGV(Error, TEXT("UniqueNetIdRepl.IsValid() == false"));
 		return;
 	}
 

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameState.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameState.cpp
@@ -170,7 +170,6 @@ void AADInGameState::BeginPlay()
 
 	TeamCreditsChangedDelegate.Broadcast(TeamCredits);
 	CurrentPhaseChangedDelegate.Broadcast(CurrentPhase);
-	CurrentPhaseGoalChangedDelegate.Broadcast(CurrentPhaseGoal);
 }
 
 void AADInGameState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
@@ -191,7 +190,6 @@ void AADInGameState::PostNetInit()
 
 	TeamCreditsChangedDelegate.Broadcast(TeamCredits);
 	CurrentPhaseChangedDelegate.Broadcast(CurrentPhase);
-	CurrentPhaseGoalChangedDelegate.Broadcast(CurrentPhaseGoal);
 }
 
 void AADInGameState::AddTeamCredit(int32 Credit)
@@ -254,12 +252,6 @@ void AADInGameState::OnRep_Phase()
 	// UI 업데이트
 	UE_LOG(LogTemp, Log, TEXT("Phase updated: %d/%d"), CurrentPhase, MaxPhase);
 	CurrentPhaseChangedDelegate.Broadcast(CurrentPhase);
-}
-
-void AADInGameState::OnRep_PhaseGoal()
-{
-	LOGVN(Error, TEXT("PhaseGoal updated: %d"), CurrentPhaseGoal);
-	CurrentPhaseGoalChangedDelegate.Broadcast(CurrentPhaseGoal);
 }
 
 void AADInGameState::OnRep_CurrentDroneSeller()
@@ -329,13 +321,7 @@ void AADInGameState::ReceiveDataFromGameInstance()
 	{
 		SelectedLevelName = ADGameInstance->SelectedLevelName;
 		TeamCredits = ADGameInstance->TeamCredits;
-		if (const FPhaseGoalRow* GoalData = ADGameInstance->GetSubsystem<UDataTableSubsystem>()->GetPhaseGoalData(SelectedLevelName, CurrentPhase))
-		{
-			CurrentPhaseGoal = GoalData->GoalCredit;
-		}
 	}
-
-	LOGVN(Error, TEXT("SelectedLevelName: %d / TeamCredits: %d / CurrentPhaseGoal : %d"), SelectedLevelName, TeamCredits, CurrentPhaseGoal);
 }
 
 void AADInGameState::SetDestinationTarget(AActor* NewDestinationTarget)

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameState.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameState.h
@@ -124,7 +124,6 @@ public:
 
 	FOnGameStatePropertyChangedDelegate TeamCreditsChangedDelegate;
 	FOnGameStatePropertyChangedDelegate CurrentPhaseChangedDelegate;
-	FOnGameStatePropertyChangedDelegate CurrentPhaseGoalChangedDelegate;
 	FOnMissionListRefreshedDelegate OnMissionListRefreshedDelegate;
 
 protected:
@@ -136,9 +135,6 @@ protected:
 
 	UFUNCTION()
 	void OnRep_Phase();
-
-	UFUNCTION()
-	void OnRep_PhaseGoal();
 
 	UFUNCTION()
 	void OnRep_CurrentDroneSeller();
@@ -164,9 +160,6 @@ protected:
 
 	UPROPERTY(ReplicatedUsing = OnRep_Phase, BlueprintReadOnly)
 	uint8 CurrentPhase;
-
-	UPROPERTY(ReplicatedUsing = OnRep_PhaseGoal, BlueprintReadOnly)
-	int32 CurrentPhaseGoal = 0;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	uint8 MaxPhase = 3;
@@ -214,19 +207,6 @@ public:
 	uint8 GetPhase() const { return CurrentPhase; }
 
 	uint8 GetMaxPhase() const { return MaxPhase; }
-
-	FORCEINLINE void SetCurrentPhaseGoal(int32 NewPhaseGoal) 
-	{ 
-		if (HasAuthority() == false)
-		{
-			return;
-		}
-
-		CurrentPhaseGoal = NewPhaseGoal;
-		CurrentPhaseGoalChangedDelegate.Broadcast(NewPhaseGoal);
-	}
-
-	int32 GetCurrentPhaseGoal() const { return CurrentPhaseGoal; }
 
 	void SetSelectedLevel(EMapName LevelName) { SelectedLevelName = LevelName; }
 	EMapName GetSelectedLevel() const { return SelectedLevelName; }

--- a/Source/AbyssDiverUnderWorld/Framework/ADPlayerState.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADPlayerState.cpp
@@ -16,7 +16,6 @@ AADPlayerState::AADPlayerState()
 	, OreMinedCount(0)
 	, bIsSafeReturn(false)
 	, PlayerIndex(INDEX_NONE)
-	, bIsHost(false)
 {
 	bReplicates = true;
 
@@ -72,16 +71,24 @@ void AADPlayerState::CopyProperties(APlayerState* PlayerState)
 {
 	Super::CopyProperties(PlayerState);
 
-	if (ensure(this) == false || ensure(PlayerState) == false)
+	if (IsValid(this) == false)
 	{
+		LOGVN(Error, TEXT("IsValid(this) == false"));
+		return;
+	}
+
+	if (IsValid(PlayerState) == false)
+	{
+		LOGVN(Error, TEXT("IsValid(PlayerState) == false"));
 		return;
 	}
 
 	AADPlayerState* NextPlayerState = CastChecked<AADPlayerState>(PlayerState);
 
 	const FUniqueNetIdRepl& UniqueNetIdRepl = NextPlayerState->GetUniqueId();
-	if (ensure(&UniqueNetIdRepl) == false)
+	if (UniqueNetIdRepl.IsValid() == false)
 	{
+		LOGVN(Error, TEXT("UniqueNetIdRepl.IsValid() == false"));
 		return;
 	}
 

--- a/Source/AbyssDiverUnderWorld/Framework/ADPlayerState.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADPlayerState.h
@@ -75,9 +75,6 @@ protected:
 	UPROPERTY(Replicated)
 	int8 PlayerIndex;
 
-	UPROPERTY(Replicated)
-	uint8 bIsHost : 1;
-
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
 	TObjectPtr<UADInventoryComponent> InventoryComp;
 
@@ -141,12 +138,6 @@ public:
 	void SetIsSafeReturn(bool bValue) { bIsSafeReturn = bValue; }
 	UFUNCTION(BlueprintPure)
 	bool IsSafeReturn() const { return bIsSafeReturn; }
-
-	// bIsHost
-	UFUNCTION(BlueprintCallable)
-	void SetIsHost(bool bValue) { bIsHost = bValue; }
-	UFUNCTION(BlueprintPure)
-	bool IsHost() const { return bIsHost; }
 
 	FORCEINLINE UADInventoryComponent* GetInventory() const { return InventoryComp; };
 	FORCEINLINE UUpgradeComponent* GetUpgradeComp() const { return UpgradeComp; };

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/Radar.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/Radar.cpp
@@ -118,7 +118,23 @@ void ARadar::Tick(float DeltaTime)
 			}
 			else
 			{
-				FindIfReturnIsValidResponseForRader(FoundActor);
+				TArray<URadarReturnComponent*> RadarReturns;
+				FoundActor->GetComponents<URadarReturnComponent>(RadarReturns);
+
+				bool bIsRemoved = false;
+				for (auto& RadarReturn : RadarReturns)
+				{
+					if (RadarReturn->GetIgnore())
+					{
+						RemoveReturn(RadarReturn, 0);
+						bIsRemoved = true;
+					}
+				}
+
+				if (bIsRemoved == false)
+				{
+					FindIfReturnIsValidResponseForRader(FoundActor);
+				}
 			}
 		}
 	}

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturnComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturnComponent.cpp
@@ -355,3 +355,13 @@ bool URadarReturnComponent::ShouldLimitOpacityToRadarDisplayForPing() const
 	return bShouldLimitOpacityToRadarDisplayForPing;
 }
 
+bool URadarReturnComponent::GetIgnore() const
+{
+	return bShouldIgnore;
+}
+
+void URadarReturnComponent::SetIgnore(bool bIgnore)
+{
+	bShouldIgnore = bIgnore;
+}
+

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturnComponent.h
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturnComponent.h
@@ -166,6 +166,9 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RadarReturn")
 	FString ScaleFromRootComponentName;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RadarReturn")
+	uint8 bShouldIgnore : 1;
+
 #pragma endregion
 
 #pragma region Getters, Setters
@@ -224,6 +227,9 @@ public:
 	bool ShouldLimitOpacityToRadarDisplayForStand() const;
 	bool HasReturnPing() const;
 	bool ShouldLimitOpacityToRadarDisplayForPing() const;
+
+	bool GetIgnore() const;
+	void SetIgnore(bool bIgnore);
 
 #pragma endregion
 };

--- a/Source/AbyssDiverUnderWorld/UI/CurrentZone.cpp
+++ b/Source/AbyssDiverUnderWorld/UI/CurrentZone.cpp
@@ -117,6 +117,7 @@ void ACurrentZone::OnDeepTriggerOverlapBegin(UPrimitiveComponent* OverlappedComp
         }
 
         AffectedCharacters[Character] = true;
+        LOGV(Log, TEXT(" %s is In DeepCurrent"), *Character->GetName());
     }
 }
 
@@ -130,6 +131,7 @@ void ACurrentZone::OnDeepTriggerOverlapEnd(UPrimitiveComponent* OverlappedComp, 
         }
 
         AffectedCharacters[Character] = false;
+        LOGV(Log, TEXT(" %s is Out of DeepCurrent"), *Character->GetName());
     }
 }
 
@@ -150,6 +152,17 @@ void ACurrentZone::ApplyCurrentForce()
         }
 
         // 캐릭터 속도 0.1배 만들기 필요
+        bool bIsInDeepCurrentZone = CharacterPair.Value;
+        if (bIsInDeepCurrentZone)
+        {
+            Character->SetZoneSpeedMultiplier(0.1f);
+            LOGV(Log, TEXT(" %s : 0.1"), *Character->GetName());
+        }
+        else
+        {
+            Character->SetZoneSpeedMultiplier(1.0f);
+            LOGV(Log, TEXT(" %s : 1.0"), *Character->GetName());
+        }
 
         FVector PushDir = PushDirection.GetSafeNormal();
         float FinalFlowStrength = FlowStrength;


### PR DESCRIPTION


---

## 📝 작업 상세 내용
### 레이더 무시 기능
- RadarReturnComponent : bShouldIgnore을 설정해줌으로써 레이더에 표시되지 않도록 설정 가능
- BP_Big_SerpMare : 레이더에 띄우지 않음

### 나침반 드론 표시 기능 개선
- Z축을 고려하지않고 나침반에 드론 표시, 이제 머리 위에 있어도 잘 나옴
- 드론 점등 효과 추가 : 가까울수록 진하게 점등

### 급류 개선
- 급류의 중심에 다가가면 캐릭터의 속도가 0.1배 되도록 수정

### 크래시 의심 코드 수정
- ADInGameMode : LogOut에 방어 코드 추가
- ADPlayerState : CopyProperties에 방어 코드 추가, 사용하지 않는 Replicated 변수 삭제
- ADInGameState : 사용하지 않는 Replicated 변수 삭제

---
