### PR TITLE
✨ update 상점 아이템 날리기 기능 개선 🐛 bugfix 미션 유지 현상, Pause후 게임 나갈시 인풋

### DIFF
--- a/Content/_AbyssDiver/Blueprints/UI/MainMenu/WBP_PauseWidget.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/MainMenu/WBP_PauseWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1eb2796069e9a52a8b737b8371a53114cdff03c307343e7fbc2e0ee3297ac5cf
-size 79991
+oid sha256:084c49507dea1dd3222de04c06fa1a6f0f8e43781970daf7ece8925b4184d0f1
+size 83925

--- a/Source/AbyssDiverUnderWorld/Framework/ADCampGameMode.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADCampGameMode.cpp
@@ -8,6 +8,7 @@
 #include "DataRow/PhaseGoalRow.h"
 #include "AbyssDiverUnderWorld.h"
 #include "Subsystems/DataTableSubsystem.h"
+#include "Subsystems/MissionSubsystem.h"
 
 #include "Kismet/GameplayStatics.h"
 #include "EngineUtils.h"
@@ -32,6 +33,15 @@ void AADCampGameMode::PostLogin(APlayerController* NewPlayer)
 	LOGV(Warning, TEXT("%s Has Entered"), *NewPlayerId);
 	UADGameInstance* GI = GetGameInstance<UADGameInstance>();
 	check(GI);
+
+	UMissionSubsystem* MissionSubsystem = GI->GetSubsystem<UMissionSubsystem>();
+	if (MissionSubsystem == nullptr)
+	{
+		LOGV(Error, TEXT("Fail to get MissionSubsystem"));
+		return;
+	}
+
+	MissionSubsystem->RemoveAllMissions();
 
 	if (AADPlayerState* ADPlayerState = NewPlayer->GetPlayerState<AADPlayerState>())
 	{
@@ -59,6 +69,15 @@ void AADCampGameMode::Logout(AController* Exiting)
 	FString ExitingId = Exiting->GetPlayerState<AADPlayerState>()->GetUniqueId().GetUniqueNetId()->ToString();
 	UADGameInstance* GI = GetGameInstance<UADGameInstance>();
 	GI->RemovePlayerNetId(ExitingId);
+
+	UMissionSubsystem* MissionSubsystem = GI->GetSubsystem<UMissionSubsystem>();
+	if (MissionSubsystem == nullptr)
+	{
+		LOGV(Error, TEXT("Fail to get MissionSubsystem"));
+		return;
+	}
+
+	MissionSubsystem->RemoveAllMissions();
 }
 
 void AADCampGameMode::InitGameState()

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.cpp
@@ -10,6 +10,7 @@
 
 #include "Subsystems/SoundSubsystem.h"
 #include "Subsystems/DataTableSubsystem.h"
+#include "Subsystems/MissionSubsystem.h"
 
 #include "Character/PlayerComponent/PlayerHUDComponent.h"
 #include "Character/UnderwaterCharacter.h"
@@ -105,6 +106,15 @@ void AADInGameMode::PostLogin(APlayerController* NewPlayer)
 	UADGameInstance* GI = GetGameInstance<UADGameInstance>();
 	check(GI);
 
+	UMissionSubsystem* MissionSubsystem = GI->GetSubsystem<UMissionSubsystem>();
+	if (MissionSubsystem == nullptr)
+	{
+		LOGV(Error, TEXT("Fail to get MissionSubsystem"));
+		return;
+	}
+
+	MissionSubsystem->RemoveAllMissions();
+
 	if (AADPlayerState* ADPlayerState = NewPlayer->GetPlayerState<AADPlayerState>())
 	{
 		ADPlayerState->ResetLevelResults();
@@ -154,6 +164,15 @@ void AADInGameMode::Logout(AController* Exiting)
 	UADGameInstance* GI = GetGameInstance<UADGameInstance>();
 	GI->RemovePlayerNetId(ExitingId);
 
+	UMissionSubsystem* MissionSubsystem = GI->GetSubsystem<UMissionSubsystem>();
+	if (MissionSubsystem == nullptr)
+	{
+		LOGV(Error, TEXT("Fail to get MissionSubsystem"));
+		return;
+	}
+
+	MissionSubsystem->RemoveAllMissions();
+
 	LOGVN(Error, TEXT("Logout, Who : %s, NetId : %s"), *Exiting->GetName(), *ExitingId);
 
 }
@@ -175,8 +194,6 @@ void AADInGameMode::ReadyForTravelToCamp()
 
 	TimerManager.ClearTimer(ResultTimerHandle);
 
-	
-
 	const float Interval = 5.0f;
 	TimerManager.SetTimer(ResultTimerHandle, this, &AADInGameMode::TravelToCamp, 1, false, Interval);
 }
@@ -188,6 +205,14 @@ void AADInGameMode::TravelToCamp()
 		PC->C_OnPreClientTravel();
 	}
 
+	UMissionSubsystem* MissionSubsystem = GetGameInstance()->GetSubsystem<UMissionSubsystem>();
+	if (MissionSubsystem == nullptr)
+	{
+		LOGV(Error, TEXT("Fail to get MissionSubsystem"));
+		return;
+	}
+
+	MissionSubsystem->RemoveAllMissions();
 	const float WaitForStopVoice = 1.0f;
 
 	FTimerHandle WaitForVoiceTimerHandle;

--- a/Source/AbyssDiverUnderWorld/Interactable/Item/ADUseItem.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/Item/ADUseItem.cpp
@@ -90,6 +90,16 @@ void AADUseItem::SetVariableValues(int32 InAmount, int32 InCurrentAmmo, int32 In
 	ItemData.ReserveAmmo = InReserveAmmo;
 }
 
+float AADUseItem::GetMeshMass() const
+{
+	if (IsValid(SkeletalMesh) == false)
+	{
+		return 0.0f;
+	}
+
+	return SkeletalMesh->GetMass();
+}
+
 void AADUseItem::M_UnEquipMode_Implementation()
 {
 	SkeletalMesh->SetGenerateOverlapEvents(true);

--- a/Source/AbyssDiverUnderWorld/Interactable/Item/ADUseItem.h
+++ b/Source/AbyssDiverUnderWorld/Interactable/Item/ADUseItem.h
@@ -54,7 +54,8 @@ private:
 #pragma region Getter, Setter
 public:
 	UEquipableComponent* GetEquipableComponent() { return EquipableComp; }
-	void SetItemVisiblity(bool InVisible);
+	// 유효하지 않으면 0.0f 반환
+	float GetMeshMass() const;
 
 #pragma endregion
 };

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.cpp
@@ -975,71 +975,15 @@ void AShop::OnBuyListEntryClicked(int32 ClickedSlotIndex)
 
 void AShop::OnAddButtonClicked(int32 Quantity)
 {
-	AADInGameState* GS = CastChecked<AADInGameState>(UGameplayStatics::GetGameState(GetWorld()));
-	UDataTableSubsystem* DataTableSubsystem = GetGameInstance()->GetSubsystem<UDataTableSubsystem>();
-
-	int32 TotalTeamCredit = GS->GetTotalTeamCredit();
-
 	EShopCategoryTab CurrentTab = ShopWidget->GetCurrentActivatedTab();
-
 	if (CurrentTab == EShopCategoryTab::Upgrade)
 	{
-		APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
-		AADPlayerState* PS = PC->GetPlayerState<AADPlayerState>();
-		if (PS == nullptr)
-		{
-			LOGS(Error, TEXT("PS == nullptr"));
-			return;
-		}
-
-		UUpgradeComponent* UpgradeComp = PS->GetUpgradeComp();
-		if (UpgradeComp == nullptr)
-		{
-			LOGS(Error, TEXT("UpgradeComp == nullptr"));
-			return;
-		}
-
-		bool bIsMaxGrade = UpgradeComp->IsMaxGrade(CurrentSelectedUpgradeType);
-		if (bIsMaxGrade)
-		{
-			LOGS(Log, TEXT("This Upgrade Type Has Reached to Max Level"));
-			return;
-		}
-
-		int32 Grade = UpgradeComp->GetCurrentGrade(CurrentSelectedUpgradeType);
-		FUpgradeDataRow* UpgradeData = DataTableSubsystem->GetUpgradeData(CurrentSelectedUpgradeType, Grade + 1);
-
-		if (TotalTeamCredit < UpgradeData->Price)
-		{
-			LOGS(Warning, TEXT("업그레이드 돈부족!! 남은 돈 : %d, 필요한 돈 : %d"), TotalTeamCredit, UpgradeData->Price);
-			return;
-		}
-		
-		UpgradeComp->S_RequestUpgrade(CurrentSelectedUpgradeType);
 		return;
 	}
 
-	/*AUnderwaterCharacter* BuyingCharacter = Cast<AUnderwaterCharacter>(UGameplayStatics::GetPlayerController(GetWorld(), 0)->GetPawn());
-	if (BuyingCharacter == nullptr)
-	{
-		LOGS(Warning, TEXT("BuyingCharacter == nullptr"));
-		return;
-	}
-
-	UShopInteractionComponent* ShopInteractionComp = BuyingCharacter->GetShopInteractionComponent();
-	if (ShopInteractionComp == nullptr)
-	{
-		LOGS(Warning, TEXT("ShopInteractionComp == nullptr"));
-		return;
-	}*/
-
+	AADInGameState* GS = CastChecked<AADInGameState>(UGameplayStatics::GetGameState(GetWorld()));
+	UDataTableSubsystem* DataTableSubsystem = GetGameInstance()->GetSubsystem<UDataTableSubsystem>();
 	FFADItemDataRow* ItemData = DataTableSubsystem->GetItemData(CurrentSelectedItemId);
-
-	/*if (TotalTeamCredit < ItemData->Price * Quantity)
-	{
-		LOGS(Warning, TEXT("아이템 구매 돈부족!! 남은 돈 : %d, 필요한 돈 : %d"), TotalTeamCredit, ItemData->Price * Quantity);
-		return;
-	}*/
 
 	UShopBuyListEntryData* BuyListEntryData = ShopWidget->AddToBuyList(CurrentSelectedItemId, Quantity);
 	if (BuyListEntryData == nullptr)
@@ -1059,44 +1003,84 @@ void AShop::OnAddButtonClicked(int32 Quantity)
 	}
 
 	BuyListEntryData->OnEntryUpdatedFromDataDelegate.AddUObject(this, &AShop::OnSlotEntryWidgetUpdated);
-
-	//ShopInteractionComp->S_RequestBuyItem(CurrentSelectedItemId, Quantity);
 }
 
 void AShop::OnBuyButtonClicked()
 {
-	int32 TotalItemPrice = CalcTotalItemPrice(SelectedItemIdArray, SelectedItemCountArray);
-	if (TotalItemPrice == INDEX_NONE)
+	AADInGameState* GS = CastChecked<AADInGameState>(UGameplayStatics::GetGameState(GetWorld()));
+	UDataTableSubsystem* DataTableSubsystem = GetGameInstance()->GetSubsystem<UDataTableSubsystem>();
+
+	int32 TotalTeamCredit = GS->GetTotalTeamCredit();
+
+	EShopCategoryTab CurrentTab = ShopWidget->GetCurrentActivatedTab();
+
+	if (CurrentTab == EShopCategoryTab::Upgrade && CurrentSelectedUpgradeType != EUpgradeType::Max)
 	{
-		LOGV(Error, TEXT("Fail to Calculate Total Item Price"));
-		return;
+		APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
+		AADPlayerState* PS = PC->GetPlayerState<AADPlayerState>();
+		if (PS == nullptr)
+		{
+			LOGV(Error, TEXT("PS == nullptr"));
+			return;
+		}
+
+		UUpgradeComponent* UpgradeComp = PS->GetUpgradeComp();
+		if (UpgradeComp == nullptr)
+		{
+			LOGV(Error, TEXT("UpgradeComp == nullptr"));
+			return;
+		}
+
+		bool bIsMaxGrade = UpgradeComp->IsMaxGrade(CurrentSelectedUpgradeType);
+		if (bIsMaxGrade)
+		{
+			LOGV(Log, TEXT("This Upgrade Type Has Reached to Max Level"));
+			return;
+		}
+
+		int32 Grade = UpgradeComp->GetCurrentGrade(CurrentSelectedUpgradeType);
+		FUpgradeDataRow* UpgradeData = DataTableSubsystem->GetUpgradeData(CurrentSelectedUpgradeType, Grade + 1);
+
+		if (TotalTeamCredit < UpgradeData->Price)
+		{
+			LOGV(Log, TEXT("업그레이드 돈부족!! 남은 돈 : %d, 필요한 돈 : %d"), TotalTeamCredit, UpgradeData->Price);
+			return;
+		}
+
+		UpgradeComp->S_RequestUpgrade(CurrentSelectedUpgradeType);
 	}
-
-	AADInGameState* GS = Cast<AADInGameState>(UGameplayStatics::GetGameState(GetWorld()));
-	check(GS);
-
-	int32 TeamCredits = GS->GetTotalTeamCredit();
-	if (TeamCredits < TotalItemPrice)
+	else
 	{
-		LOGV(Log, TEXT("Not Enough Money, Needed : %d, Held : %d"), TotalItemPrice, TeamCredits);
-		return;
-	}
+		int32 TotalItemPrice = CalcTotalItemPrice(SelectedItemIdArray, SelectedItemCountArray);
+		if (TotalItemPrice == INDEX_NONE)
+		{
+			LOGV(Error, TEXT("Fail to Calculate Total Item Price"));
+			return;
+		}
 
-	AUnderwaterCharacter* BuyingCharacter = Cast<AUnderwaterCharacter>(UGameplayStatics::GetPlayerController(GetWorld(), 0)->GetPawn());
-	if (BuyingCharacter == nullptr)
-	{
-		LOGV(Warning, TEXT("BuyingCharacter == nullptr"));
-		return;
-	}
+		if (TotalTeamCredit < TotalItemPrice)
+		{
+			LOGV(Log, TEXT("Not Enough Money, Needed : %d, Held : %d"), TotalItemPrice, TotalTeamCredit);
+			return;
+		}
 
-	UShopInteractionComponent* ShopInteractionComp = BuyingCharacter->GetShopInteractionComponent();
-	if (ShopInteractionComp == nullptr)
-	{
-		LOGV(Warning, TEXT("ShopInteractionComp == nullptr"));
-		return;
-	}
+		AUnderwaterCharacter* BuyingCharacter = Cast<AUnderwaterCharacter>(UGameplayStatics::GetPlayerController(GetWorld(), 0)->GetPawn());
+		if (BuyingCharacter == nullptr)
+		{
+			LOGV(Warning, TEXT("BuyingCharacter == nullptr"));
+			return;
+		}
 
-	ShopInteractionComp->S_RequestBuyItems(SelectedItemIdArray, SelectedItemCountArray);
+		UShopInteractionComponent* ShopInteractionComp = BuyingCharacter->GetShopInteractionComponent();
+		if (ShopInteractionComp == nullptr)
+		{
+			LOGV(Warning, TEXT("ShopInteractionComp == nullptr"));
+			return;
+		}
+
+		ShopInteractionComp->S_RequestBuyItems(SelectedItemIdArray, SelectedItemCountArray);
+		ClearSelectedInfos();
+	}
 }
 
 void AShop::OnCloseButtonClicked()
@@ -1124,7 +1108,7 @@ void AShop::OnUpgradeSlotEntryClicked(int32 ClickedSlotIndex)
 	UUpgradeComponent* UpgradeComp = PS->GetUpgradeComp();
 	if (UpgradeComp == nullptr)
 	{
-		LOGS(Error, TEXT("UpgradeComp == nullptr"));
+		LOGV(Error, TEXT("UpgradeComp == nullptr"));
 		return;
 	}
 
@@ -1133,14 +1117,14 @@ void AShop::OnUpgradeSlotEntryClicked(int32 ClickedSlotIndex)
 	uint8 CurrentGrade = UpgradeComp->GetCurrentGrade(UpgradeType);
 	if (CurrentGrade == 0)
 	{
-		LOGS(Log, TEXT("Weird Upgrade Type Detected : %d"), UpgradeType);
+		LOGV(Log, TEXT("Weird Upgrade Type Detected : %d"), UpgradeType);
 		return;
 	}
 
 	UDataTableSubsystem* DataTableSubSystem = GetGameInstance()->GetSubsystem<UDataTableSubsystem>();
 	if (DataTableSubSystem == nullptr)
 	{
-		LOGS(Error, TEXT("DataTableSubSystem == nullptr"));
+		LOGV(Error, TEXT("DataTableSubSystem == nullptr"));
 		return;
 	}
 
@@ -1151,7 +1135,7 @@ void AShop::OnUpgradeSlotEntryClicked(int32 ClickedSlotIndex)
 	ShopWidget->ShowUpgradeInfos(UpgradeType, CurrentGrade, bIsMaxGrade);
 	CurrentSelectedUpgradeType = UpgradeType;
 
-	LOGS(Log, TEXT("UpgradeViewSlotClicked, Index : %d"), ClickedSlotIndex);
+	LOGV(Log, TEXT("UpgradeViewSlotClicked, Index : %d"), ClickedSlotIndex);
 }
 
 int8 AShop::IsSelectedItem(uint8 ItemId) const
@@ -1346,12 +1330,24 @@ void AShop::LaunchItem()
 	}
 
 	SpawnedItem->M_SetItemVisible(true);
-	//SpawnedItem->FinishSpawning(OriginPoint->GetActorTransform(), false);
 
-	FVector LaunchDirection = DestinationPoint->GetActorLocation() - OriginPoint->GetActorLocation();
+	FVector Destination = DestinationPoint->GetActorLocation();
+	Destination.X += FMath::RandRange(-ErrorOfLaunchDirection, ErrorOfLaunchDirection);
+	Destination.Y += FMath::RandRange(-ErrorOfLaunchDirection, ErrorOfLaunchDirection);
+	Destination.Z += FMath::RandRange(-ErrorOfLaunchDirection, ErrorOfLaunchDirection);
+
+	FVector LaunchDirection = Destination - OriginPoint->GetActorLocation();
 	LaunchDirection.Normalize();
 
-	ItemRoot->AddImpulse(LaunchDirection * ForceAmount);
+	float ItemMeshMass = SpawnedItem->GetMeshMass();
+	if (ItemMeshMass == 0.0f)
+	{
+		LOGV(Error, TEXT("Invalid Mesh"));
+		return;
+	}
+
+	float ActualForce = ForceAmount * ItemMeshMass;
+	ItemRoot->AddImpulse(LaunchDirection * ActualForce);
 }
 
 void AShop::ClearSelectedInfos()

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.h
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.h
@@ -268,6 +268,9 @@ protected:
 	UPROPERTY(EditAnywhere, Category = "ShopSettings")
 	float LaunchItemIntervalAtFirst = 1.0f;
 
+	UPROPERTY(EditAnywhere, Category = "ShopSettings")
+	float ErrorOfLaunchDirection = 1.0f;
+
 	UPROPERTY(Replicated)
 	FShopItemIdList ShopConsumableItemIdList;
 

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.cpp
@@ -73,7 +73,7 @@ void UShopElementInfoWidget::Init(USkeletalMeshComponent* NewItemMeshComp)
 	SetItemMeshActive(false);
 	SetDescriptionActive(false);
 	SetNameInfoTextActive(false);
-	SetBuyButtonActive(false);
+	SetAddButtonActive(false);
 	SetUpgradeLevelInfoActive(false);
 	SetCostInfoActive(false);
 	SetQuantityOverlayActive(false);
@@ -104,7 +104,7 @@ void UShopElementInfoWidget::ShowItemInfos(int32 ItemId)
 	SetItemMeshActive(true);
 	SetDescriptionActive(true);
 	SetNameInfoTextActive(true);
-	SetBuyButtonActive(true);
+	SetAddButtonActive(true);
 	SetUpgradeLevelInfoActive(false);
 	SetCostInfoActive(true);
 	SetQuantityOverlayActive(true); 
@@ -162,7 +162,7 @@ void UShopElementInfoWidget::ShowUpgradeInfos(EUpgradeType UpgradeType, uint8 Gr
 	SetItemMeshActive(false);
 	SetDescriptionActive(true);
 	SetNameInfoTextActive(true);
-	SetBuyButtonActive(true);
+	SetAddButtonActive(false);
 	SetUpgradeLevelInfoActive(true);
 	SetCostInfoActive(true);
 	SetQuantityOverlayActive(false);
@@ -287,7 +287,7 @@ void UShopElementInfoWidget::SetItemMeshActive(bool bShouldActivate)
 	ItemMeshPanel->SetItemMeshActive(bShouldActivate);
 }
 
-void UShopElementInfoWidget::SetBuyButtonActive(bool bShouldActivate)
+void UShopElementInfoWidget::SetAddButtonActive(bool bShouldActivate)
 {
 	if (bShouldActivate)
 	{

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopElementInfoWidget.h
@@ -47,7 +47,7 @@ public:
 	void SetDescriptionActive(bool bShouldActivate);
 	void SetNameInfoTextActive(bool bShouldActivate);
 	void SetItemMeshActive(bool bShouldActivate);
-	void SetBuyButtonActive(bool bShouldActivate);
+	void SetAddButtonActive(bool bShouldActivate);
 
 	void SetUpgradeLevelInfoActive(bool bShouldActivate);
 	void SetCostInfoActive(bool bShouldActivate);

--- a/Source/AbyssDiverUnderWorld/Subsystems/MissionSubsystem.cpp
+++ b/Source/AbyssDiverUnderWorld/Subsystems/MissionSubsystem.cpp
@@ -171,7 +171,7 @@ void UMissionSubsystem::ReceiveMissionDataFromUIData(const TArray<FMissionData>&
 		return;
 	}
 
-	Missions.Empty(MissionsFromUI.Num());
+	Missions.Reset(MissionsFromUI.Num());
 
 	for (const FMissionData& MissionFromUI : MissionsFromUI)
 	{
@@ -307,6 +307,11 @@ void UMissionSubsystem::RequestUnbinding(UObject* Requester)
 	{
 		Mission->UnbindDelegates(Requester);
 	}
+}
+
+void UMissionSubsystem::RemoveAllMissions()
+{
+	Missions.Reset();
 }
 
 void UMissionSubsystem::MakeAndAddMissionDataForUI(const FMissionBaseRow* MissionBaseData, const uint8& MissionIndex)

--- a/Source/AbyssDiverUnderWorld/Subsystems/MissionSubsystem.h
+++ b/Source/AbyssDiverUnderWorld/Subsystems/MissionSubsystem.h
@@ -47,6 +47,8 @@ public:
 	void RequestBinding(UObject* Requester);
 	void RequestUnbinding(UObject* Requester);
 
+	void RemoveAllMissions();
+
 private:
 
 	void MakeAndAddMissionDataForUI(const FMissionBaseRow* MissionBaseData, const uint8& MissionIndex);


### PR DESCRIPTION


---

## 📝 작업 상세 내용
### ✨ update 상점 아이템 날리기 기능 개선
- 아이템마다 질량에 비례하여 날리는 힘 다르게 조절
- 날리는 방향 오차 부여하는 기능 추가

### 🐛 bugfix 미션 유지 현상, Pause후 게임 나갈시 인풋
- 이전에 받았던 미션이 여전히 남아있는 현상 수정
- Pause로 게임을 나가고 게임을 재시작 할 시 인풋이 안먹히는 현상 해결

---
