### PR TITLE
🐛 bugfix 상점 버그, 부활 버그, 게임 오버 버그

### DIFF
--- a/Source/AbyssDiverUnderWorld/DataRow/MissionDataRow/MissionBaseRow.h
+++ b/Source/AbyssDiverUnderWorld/DataRow/MissionDataRow/MissionBaseRow.h
@@ -12,7 +12,8 @@ enum class EMissionType : uint8
 	Interaction,
 	ItemCollection,
 	ItemUse,
-	KillMonster
+	KillMonster,
+	MAX UMETA(Hidden)
 };
 
 UENUM(BlueprintType)

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.h
@@ -11,6 +11,7 @@ enum class ECharacterState : uint8;
 class AGenericPool;
 class USoundSubsystem;
 class AUnderwaterCharacter;
+class AADDrone;
 
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API AADInGameMode : public AGameMode
@@ -24,6 +25,7 @@ public:
 	virtual void BeginPlay() override;
 	virtual void PostLogin(APlayerController* NewPlayer) override;
 	virtual void Logout(AController* Exiting) override;
+	virtual void FinishRestartPlayer(AController* NewPlayer, const FRotator& StartRotation) override;
 
 #pragma region Methods
 
@@ -38,6 +40,7 @@ public:
 
 	/** Spawn Center 중심으로 지정된 거리 내에서 랜덤한 위치를 선택하여 플레이어들을 부활시킨다. */
 	void RevivePlayersAtRandomLocation(TArray<int8> PlayerIndexes, const FVector& SpawnCenter, float ReviveDistance);
+	void RevivePlayersAroundDroneAtRespawnLocation(const TArray<int8>& PlayerIndexes, const AADDrone* SomeDrone);
 
 	/** 지정된 인덱스의 플레이어 컨트롤러를 찾는다. */
 	AADPlayerController* FindPlayerControllerFromIndex(int8 PlayerIndex) const;
@@ -49,6 +52,8 @@ protected:
 	/** 지정된 위치에서 지정된 거리 내에서 랜덤한 위치를 반환한다. */
 	FVector GetRandomLocation(const FVector& Location, float Distance) const;
 	
+	void RestartPlayerFromPlayerIndex(int8 PlayerIndex, const FVector& SpawnLocation);
+
 private:
 
 	void GameOver();

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameState.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameState.h
@@ -27,16 +27,16 @@ struct FActivatedMissionInfo : public FFastArraySerializerItem
 	GENERATED_BODY()
 
 	UPROPERTY()
-	EMissionType MissionType;
+	EMissionType MissionType = EMissionType(0);
 
 	UPROPERTY()
-	uint8 MissionIndex;
+	uint8 MissionIndex = 0;
 
 	UPROPERTY()
-	uint8 bIsCompleted : 1;
+	uint8 bIsCompleted : 1 = false;
 
 	UPROPERTY()
-	uint8 CurrentProgress;
+	uint8 CurrentProgress = 0;
 
 	void PostReplicatedAdd(const FActivatedMissionInfoList& InArraySerializer);
 

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/ADDrone.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/ADDrone.cpp
@@ -17,6 +17,7 @@
 
 #include "Net/UnrealNetwork.h"
 #include "Kismet/GameplayStatics.h"
+#include "Engine/TargetPoint.h"
 
 DEFINE_LOG_CATEGORY(DroneLog);
 
@@ -109,10 +110,7 @@ void AADDrone::Interact_Implementation(AActor* InstigatorActor)
 	{
 		if (AADInGameMode* GameMode = GetWorld()->GetAuthGameMode<AADInGameMode>())
 		{
-			GameMode->RevivePlayersAtRandomLocation(CurrentSeller->GetSubmittedPlayerIndexes(),
-				GetActorLocation(),
-				ReviveDistance
-			);
+			GameMode->RevivePlayersAroundDroneAtRespawnLocation(CurrentSeller->GetSubmittedPlayerIndexes(), this);
 			CurrentSeller->GetSubmittedPlayerIndexes().Empty();
 		}
 	}
@@ -239,6 +237,16 @@ bool AADDrone::IsHoldMode() const
 FString AADDrone::GetInteractionDescription() const
 {
 	return TEXT("Send Drone!");
+}
+
+const TArray<ATargetPoint*>& AADDrone::GetPlayerRespawnLocations() const
+{
+	return PlayerRespawnLocations;
+}
+
+float AADDrone::GetReviveDistance() const
+{
+	return ReviveDistance;
 }
 
 USoundSubsystem* AADDrone::GetSoundSubsystem()

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/ADDrone.h
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/ADDrone.h
@@ -15,6 +15,7 @@ class UADInteractableComponent;
 class AADDroneSeller;
 class ASpawnManager;
 class USoundSubsystem;
+class ATargetPoint;
 
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API AADDrone : public AActor,  public IIADInteractable
@@ -68,19 +69,19 @@ public:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Money")
 	int32 AccumulatedMoney = 0;
-	UPROPERTY(ReplicatedUsing = OnRep_IsActive, EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(ReplicatedUsing = OnRep_IsActive, EditAnywhere, BlueprintReadWrite, Category = "DroneSettings")
 	uint8 bIsActive : 1;
 	UPROPERTY(Replicated)
 	uint8 bIsFlying : 1;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "DroneSettings")
 	TObjectPtr<AADDroneSeller> CurrentSeller = nullptr;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "DroneSettings")
 	TObjectPtr<AADDroneSeller> NextSeller = nullptr;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "DroneSettings")
 	TObjectPtr<ASpawnManager> SpawnManager = nullptr;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "DroneSettings")
 	float RaiseSpeed = 200.f;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "DroneSettings")
 	float DestroyDelay = 5.f;
 	UPROPERTY()
 	TObjectPtr<USoundSubsystem> SoundSubsystem;
@@ -88,13 +89,16 @@ public:
 protected:
 
 	// 드론에 해당하는 Phase를 나타내는 숫자
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "DroneSettings")
 	int32 DronePhaseNumber = 0;
 
 	/** 사망 부활 반경 */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "DroneSettings")
 	float ReviveDistance;
-	
+
+	UPROPERTY(EditInstanceOnly, Category = "DroneSettings")
+	TArray<TObjectPtr<ATargetPoint>> PlayerRespawnLocations;
+
 private:
 
 	FTimerHandle DestroyHandle;
@@ -109,6 +113,9 @@ public:
 
 	int32 GetDronePhaseNumber() const { return DronePhaseNumber; }
 	virtual FString GetInteractionDescription() const override;
+
+	const TArray<ATargetPoint*>& GetPlayerRespawnLocations() const;
+	float GetReviveDistance() const;
 
 private:
 	USoundSubsystem* GetSoundSubsystem();

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/Radar.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/Radar.cpp
@@ -95,6 +95,17 @@ void ARadar::BeginPlay()
 void ARadar::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
+
+	if (RadarSourceLocationComponent == nullptr || RadarSourceRotationComponent == nullptr)
+	{
+		LOGVN(Error, TEXT("Radar Disabled"));
+
+		bIsRadarActive = false;
+		SetActorTickEnabled(false);
+
+		Destroy(); // 캐릭터가 죽음 이후 부활할 때 이전 레이더는 여전히 남은 상태. 그래서 파괴 시킴
+		return;
+	}
 	
 	if (bIsRadarActive)
 	{
@@ -531,13 +542,13 @@ void ARadar::FindIfReturnsInVisibleRange()
 
 	if (IsValid(RadarSourceLocationComponent) == false || RadarSourceLocationComponent->IsValidLowLevel() == false)
 	{
-		LOGV(Error, TEXT("RadarSourceLocationComponent is not valid"));
+		LOGVN(Error, TEXT("RadarSourceLocationComponent is not valid"));
 		return;
 	}
 
 	if (IsValid(RadarSourceRotationComponent) == false || RadarSourceRotationComponent->IsValidLowLevel() == false)
 	{
-		LOGV(Error, TEXT("RadarSourceRotationComponent is not valid"));
+		LOGVN(Error, TEXT("RadarSourceRotationComponent is not valid"));
 		return;
 	}
 
@@ -750,7 +761,7 @@ void ARadar::RotateRadarGrid()
 
 	if (IsValid(RadarSourceRotationComponent) == false || RadarSourceRotationComponent->IsValidLowLevel() == false)
 	{
-		LOGV(Error, TEXT("RadarSourceRotationComponent is not valid"));
+		LOGVN(Error, TEXT("RadarSourceRotationComponent is not valid"));
 		return;
 	}
 
@@ -824,6 +835,12 @@ void ARadar::RotateRadarGrid()
 
 void ARadar::FindRadarReturnTransformFromGrid()
 {
+	if (IsValid(RadarSourceLocationComponent) == false || RadarSourceLocationComponent->IsValidLowLevel() == false)
+	{
+		LOGVN(Error, TEXT("RadarSourceLocationComponent is not valid"));
+		return;
+	}
+
 	if (bShouldUseSphere)
 	{
 		CurrentRadarWidth = RadarOuterDimensionRadiusMetersFromSphere * 2.0f;

--- a/Source/AbyssDiverUnderWorld/Shops/Shop.h
+++ b/Source/AbyssDiverUnderWorld/Shops/Shop.h
@@ -43,7 +43,8 @@ enum class EShopItemChangeType
 	Max
 };
 
-enum class EDoorState
+UENUM()
+enum class EDoorState : uint8
 {
 	Opened,
 	Closed,
@@ -141,6 +142,7 @@ public:
 	void Modify(uint8 InIndex, uint8 NewId);
 
 	FOnShopItemListChangedDelegate OnShopItemListChangedDelegate;
+
 public:
 
 	UPROPERTY()
@@ -348,7 +350,10 @@ private:
 
 	ELaunchType CurrentLaunchType = ELaunchType::First;
 
+
+	UPROPERTY(Replicated)
 	EDoorState CurrentDoorState = EDoorState::Closed;
+
 	float CurrentDoorRate = 0.0f;
 
 #pragma endregion

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopBuyListSlotWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopBuyListSlotWidget.cpp
@@ -24,6 +24,7 @@ void UShopBuyListSlotWidget::NativeOnListItemObjectSet(UObject* ListItemObject)
     SetItemCountText(ItemCount);
 
     EntryData->OnEntryUpdatedFromDataDelegate.Broadcast(this);
+    LOGV(Error, TEXT("BuyListEntry Updated, Index : %d, Count : %d"), SlotIndex, ItemCount);
 }
 
 FReply UShopBuyListSlotWidget::NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.cpp
@@ -83,3 +83,8 @@ void UShopItemSlotWidget::SetToolTipText(const FString& NewText)
 {
     ToolTipTextBlock->SetText(FText::FromString(NewText));
 }
+
+void UShopItemSlotWidget::SetSlotIndex(int32 NewSlotIndex)
+{
+    SlotIndex = NewSlotIndex;
+}

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.h
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopItemSlotWidget.h
@@ -64,6 +64,7 @@ public:
 
 	void SetSlotImage(UTexture2D* NewTexture);
 	void SetToolTipText(const FString& NewText);
+	void SetSlotIndex(int32 NewSlotIndex);
 
 #pragma endregion
 

--- a/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/Shops/ShopWidgets/ShopWidget.cpp
@@ -350,14 +350,34 @@ void UShopWidget::RemoveBuyListAt(int32 ListIndex, int32 Amount)
 
 	if (BuyListEntryData->GetItemCount() <= Amount)
 	{
-		BuyListTileView->RemoveItem(BuyListEntryData);
 		BuyListEntryDataList.RemoveAt(ListIndex);
 		BuyListEntryItemIdList.RemoveAt(ListIndex);
+		BuyListTileView->RemoveItem(BuyListEntryData);
+
+		const int32 EntryCount = BuyListEntryDataList.Num();
+		for (int32 i = ListIndex; i < EntryCount; ++i)
+		{
+			UShopBuyListEntryData* NextSlotData = BuyListEntryDataList[i];
+			if (IsValid(NextSlotData) == false)
+			{
+				LOGV(Error, TEXT("Slot Data Is Invalid, Index : %d"), i);
+				return;
+			}
+
+			NextSlotData->SetSlotIndex(i);
+
+			UShopBuyListSlotWidget* NextSlotWidget = BuyListTileView->GetEntryWidgetFromItem<UShopBuyListSlotWidget>(NextSlotData);
+			if (NextSlotWidget == nullptr)
+			{
+				LOGV(Error, TEXT("Fail to get NextSlotWidget From BuyListEntryData"));
+				return;
+			}
+
+			NextSlotWidget->SetSlotIndex(i);
+		}
 	}
 	else
 	{
-		int32 RemainingCount = BuyListEntryData->GetItemCount() - Amount;
-
 		UShopBuyListSlotWidget* BuyListSlotWidget = BuyListTileView->GetEntryWidgetFromItem<UShopBuyListSlotWidget>(BuyListEntryData);
 		if (BuyListSlotWidget == nullptr)
 		{
@@ -365,6 +385,7 @@ void UShopWidget::RemoveBuyListAt(int32 ListIndex, int32 Amount)
 			return;
 		}
 
+		int32 RemainingCount = BuyListEntryData->GetItemCount() - Amount;
 		BuyListSlotWidget->SetItemCountText(RemainingCount);
 		BuyListEntryData->SetItemCount(RemainingCount);
 	}


### PR DESCRIPTION
---

# 📝 작업 상세 내용
## 🐛 bugfix 상점 버그
- Buy List에서 아이템을 제거할 때 크래시 나는 현상 수정
- Shop Door 클라이언트로 문의 움직임이 동기화 되지 않는 현상 수정

## 🐛 bugfix 캐릭터 부활 이후 이전 레이더가 남음, 사망 누적시 게임 오버되는 현상, 부활시 벽에 끼는 현상
### 캐릭터 부활 이후 이전 레이더가 남음
- 레이더의 Source가 없어지면 Destroy하도록 설정

### 사망 누적시 게임 오버되는 현상
- 같은 캐릭터가 여러번 사망해도 게임 오버되는 현상 수정 -> 캐릭터 부활시 DeathCount 감소시켜서 해결

### 부활시 벽에 끼는 현상
- 드론에 자체적으로 리스폰 장소 지정 가능하도록 기능 추가
- 기능 추가는 문서의 신규 기능 - 리스폰 관련 설정 참고
https://teamsparta.notion.site/1f82dc3ef5148028bc77f16add776a5f#1f82dc3ef5148031b3def0c1f18e84b7


---
