### PR TITLE
🐛 bugfix 결과창 버그, 사운드 버그 ✨ update  인게임 중에는 참여 불가, 4인 초과 참여 불가 설정 및 기타

### DIFF
--- a/Source/AbyssDiverUnderWorld/Framework/ADCampGameMode.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADCampGameMode.cpp
@@ -1,4 +1,4 @@
-#include "Framework/ADCampGameMode.h"
+﻿#include "Framework/ADCampGameMode.h"
 
 #include "Framework/ADInGameState.h"
 #include "Framework/ADPlayerState.h"
@@ -27,6 +27,18 @@ void AADCampGameMode::SetSelectedLevel(const EMapName InLevelName)
 	if (AADInGameState* ADGameState = GetGameState<AADInGameState>())
 	{
 		ADGameState->SetSelectedLevel(InLevelName);
+	}
+}
+
+void AADCampGameMode::PreLogin(const FString& Options, const FString& Address, const FUniqueNetIdRepl& UniqueId, FString& ErrorMessage)
+{
+	Super::PreLogin(Options, Address, UniqueId, ErrorMessage);
+
+	LOGV(Log, TEXT("현재 접속 인원 : %d"), GetNumPlayers());
+	if (GetGameInstance<UADGameInstance>()->MAX_PLAYER_NUMBER <= GetNumPlayers())
+	{
+		ErrorMessage = FString::Printf(TEXT("인원이 꽉찼습니다."));
+		return;
 	}
 }
 

--- a/Source/AbyssDiverUnderWorld/Framework/ADCampGameMode.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADCampGameMode.h
@@ -18,6 +18,7 @@ public:
 
 protected:
 
+	virtual void PreLogin(const FString& Options, const FString& Address, const FUniqueNetIdRepl& UniqueId, FString& ErrorMessage) override;
 	virtual void PostLogin(APlayerController* NewPlayer) override;
 	virtual void Logout(AController* Exiting) override;
 

--- a/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.cpp
@@ -5,6 +5,8 @@
 
 #include "Kismet/GameplayStatics.h"
 
+const int32 UADGameInstance::MAX_PLAYER_NUMBER = 4;
+
 UADGameInstance::UADGameInstance(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {

--- a/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.h
@@ -48,6 +48,9 @@ public:
 	void ChangeAmbientVolume(const float& NewVolume);
 
 public:
+
+	static const int32 MAX_PLAYER_NUMBER;
+
 	UPROPERTY(BlueprintReadWrite)
 	uint8 bIsHost : 1;
 
@@ -131,9 +134,6 @@ private:
 	TMap<FString, int32> PlayerIdMap;
 	TArray<bool> ValidPlayerIndexArray;
 
-	const int32 MAX_PLAYER_NUMBER = 4;
-	
-
 #pragma region Getters / Setters
 public:
 
@@ -154,6 +154,7 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "Input")
 	const TMap<FName, UInputAction*>& GetInputActionMap() const { return InputActionMap; }
+
 #pragma endregion
 
 

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.h
@@ -22,10 +22,12 @@ public:
 
 	AADInGameMode();
 
+	virtual void PreLogin(const FString& Options, const FString& Address, const FUniqueNetIdRepl& UniqueId, FString& ErrorMessage) override;
 	virtual void BeginPlay() override;
 	virtual void PostLogin(APlayerController* NewPlayer) override;
 	virtual void Logout(AController* Exiting) override;
 	virtual void FinishRestartPlayer(AController* NewPlayer, const FRotator& StartRotation) override;
+
 #pragma region Methods
 
 public:
@@ -90,6 +92,7 @@ private:
 	int32 GroggyCount = 0;
 
 	FTimerHandle ResultTimerHandle;
+	FTimerHandle SyncTimerHandle;
 
 #pragma endregion
 

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Portals/PortalToSubmarine.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Portals/PortalToSubmarine.cpp
@@ -47,28 +47,6 @@ void APortalToSubmarine::Interact_Implementation(AActor* InstigatorActor)
 	}
 
 	PS->SetIsSafeReturn(true);
-
-	if (bIsNetCullingDeactivated)
-	{
-		return;
-	}
-
-	bIsNetCullingDeactivated = true;
-
-	for (AADPlayerState* ADPlayerState : TActorRange<AADPlayerState>(GetWorld()))
-	{
-		APawn* Player = ADPlayerState->GetPawn();
-		if (Player == nullptr || IsValid(Player) == false || Player->IsValidLowLevel() == false || Player->IsPendingKillPending())
-		{
-			LOGV(Error, TEXT("Not Valid Player, PlayeStateName : %s"), *ADPlayerState->GetName());
-			continue;
-		}
-
-		ADPlayerState->GetPawn()->bAlwaysRelevant = true;
-	}
-
-	ForceNetUpdate();
-	LOGV(Log, TEXT("Releveant On"));
 }
 
 bool APortalToSubmarine::IsConditionMet()

--- a/Source/AbyssDiverUnderWorld/Subsystems/SoundSubsystem.cpp
+++ b/Source/AbyssDiverUnderWorld/Subsystems/SoundSubsystem.cpp
@@ -28,7 +28,7 @@ void USoundSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 		}
 	}
 
-	LOGV(Warning, TEXT("SFXData is Initialized, Count : %d"), SFXDataCount);
+	LOGV(Log, TEXT("SFXData is Initialized, Count : %d"), SFXDataCount);
 
 	GI->BGMDataTable->GetAllRows<FBGMDataRow>(TEXT("Getting BGMs.."), SFXBGMData);
 	SFXBGMDataCount = SFXBGMData.Num();
@@ -46,7 +46,7 @@ void USoundSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 		}
 	}
 
-	LOGV(Warning, TEXT("SFXBGMData is Initialized, Count : %d"), SFXBGMDataCount);
+	LOGV(Log, TEXT("SFXBGMData is Initialized, Count : %d"), SFXBGMDataCount);
 
 	GI->UISFXDataTable->GetAllRows<FUISFXDataRow>(TEXT("Getting UI SFXs.."), SFXUIData);
 	SFXUIDataCount = SFXUIData.Num();
@@ -64,7 +64,7 @@ void USoundSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 		}
 	}
 
-	LOGV(Warning, TEXT("SFXUIData is Initialized, Count : %d"), SFXUIDataCount);
+	LOGV(Log, TEXT("SFXUIData is Initialized, Count : %d"), SFXUIDataCount);
 
 	GI->MonsterSFXDataTable->GetAllRows<FMonsterSFXDataRow>(TEXT("Getting Monster SFXs.."), SFXMonsterData);
 	SFXMonsterDataCount = SFXMonsterData.Num();
@@ -82,7 +82,7 @@ void USoundSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 		}
 	}
 	
-	LOGV(Warning, TEXT("SFXMonsterData is Initialized, Count : %d"), SFXMonsterDataCount);
+	LOGV(Log, TEXT("SFXMonsterData is Initialized, Count : %d"), SFXMonsterDataCount);
 
 	GI->AmbientDataTable->GetAllRows<FAmbientDataRow>(TEXT("Getting Monster SFXs.."), AmbientData);
 	AmbientDataCount = AmbientData.Num();
@@ -100,7 +100,7 @@ void USoundSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 		}
 	}
 
-	LOGV(Warning, TEXT("AmbientData is Initialized, Count : %d"), AmbientDataCount);
+	LOGV(Log, TEXT("AmbientData is Initialized, Count : %d"), AmbientDataCount);
 }
 
 void USoundSubsystem::Init(const int32 InitialPoolCount)
@@ -188,6 +188,7 @@ void USoundSubsystem::StopAllBGM()
 	for (const auto& ActivatedBGM : ActivatedBGMComponents)
 	{
 		ActivatedBGM.Key->Stop();
+		ActivatedBGM.Key->SetSound(nullptr);
 	}
 }
 
@@ -196,6 +197,7 @@ void USoundSubsystem::StopAllSFX()
 	for (const auto& ActivatedSFX : ActivatedSFXComponents)
 	{
 		ActivatedSFX.Key->Stop();
+		ActivatedSFX.Key->SetSound(nullptr);
 	}
 }
 
@@ -204,6 +206,7 @@ void USoundSubsystem::StopAllAmbient()
 	for (const auto& ActivatedAmbient : ActivatedAmbientComponents)
 	{
 		ActivatedAmbient.Key->Stop();
+		ActivatedAmbient.Key->SetSound(nullptr);
 	}
 }
 
@@ -353,22 +356,22 @@ void USoundSubsystem::OnAudioFinished(UAudioComponent* FinishedAudio)
 	if (ActivatedBGMComponents.Contains(FinishedAudio))
 	{
 		ActivatedBGMComponents.Remove(FinishedAudio);
-		LOGV(Warning, TEXT("Removing BGM Comp, Activated : %d, Deactivated? : %d"), ActivatedBGMComponents.Num(), DeactivatedComponents.IsEmpty());
+		LOGV(Log, TEXT("Removing BGM Comp, Activated : %d, Deactivated? : %d"), ActivatedBGMComponents.Num(), DeactivatedComponents.IsEmpty());
 	}
 	else if(ActivatedSFXComponents.Contains(FinishedAudio))
 	{
 		ActivatedSFXComponents.Remove(FinishedAudio);
-		LOGV(Warning, TEXT("Removing SFX Comp, Activated : %d, Deactivated? : %d"), ActivatedSFXComponents.Num(), DeactivatedComponents.IsEmpty());
+		LOGV(Log, TEXT("Removing SFX Comp, Activated : %d, Deactivated? : %d"), ActivatedSFXComponents.Num(), DeactivatedComponents.IsEmpty());
 	}
 	else
 	{
 		ActivatedAmbientComponents.Remove(FinishedAudio);
-		LOGV(Warning, TEXT("Removing Ambient Comp, Activated : %d, Deactivated? : %d"), ActivatedAmbientComponents.Num(), DeactivatedComponents.IsEmpty());
+		LOGV(Log, TEXT("Removing Ambient Comp, Activated : %d, Deactivated? : %d"), ActivatedAmbientComponents.Num(), DeactivatedComponents.IsEmpty());
 	}
 
 	if (::IsValid(FinishedAudio) == false || FinishedAudio->IsValidLowLevelFast() == false || FinishedAudio->IsValidLowLevel() == false)
 	{
-		LOGV(Warning, TEXT("Trying to Deactivated, But Not Valid"));
+		LOGV(Log, TEXT("Trying to Deactivated, But Not Valid"));
 
 		if (AudioIdWithComponentMap.Contains(FinishedAudio) == false)
 		{
@@ -386,7 +389,7 @@ void USoundSubsystem::OnAudioFinished(UAudioComponent* FinishedAudio)
 	{
 		FDetachmentTransformRules Rule(EDetachmentRule::KeepWorld, false);
 		FinishedAudio->DetachFromComponent(Rule);
-		LOGV(Warning, TEXT("Detached"));
+		LOGV(Log, TEXT("Detached"));
 	}
 
 	FinishedAudio->OnAudioFinishedNative.RemoveAll(this);
@@ -410,21 +413,21 @@ int32 USoundSubsystem::Play2DInternal(USoundBase* SoundAsset, const bool& bIsBGM
 		check(ActivatedBGMComponents.Contains(NewAudio) == false);
 		ActivatedBGMComponents.Add(NewAudio, Volume);
 		NewVolume *= BGMVolume;
-		LOGV(Warning, TEXT("Play 2D Internal(BGM), Actvated : %d, Deactivated Empty? : %d"), ActivatedBGMComponents.Num(), DeactivatedComponents.IsEmpty());
+		LOGV(Log, TEXT("Play 2D Internal(BGM), Actvated : %d, Deactivated Empty? : %d"), ActivatedBGMComponents.Num(), DeactivatedComponents.IsEmpty());
 	}
 	else if (bIsAmbient)
 	{
 		check(ActivatedAmbientComponents.Contains(NewAudio) == false);
 		ActivatedAmbientComponents.Add(NewAudio, Volume);
 		NewVolume *= AmbientVolume;
-		LOGV(Warning, TEXT("Play 2D Internal(Ambient), Actvated : %d, Deactivated Empty? : %d"), ActivatedAmbientComponents.Num(), DeactivatedComponents.IsEmpty());
+		LOGV(Log, TEXT("Play 2D Internal(Ambient), Actvated : %d, Deactivated Empty? : %d"), ActivatedAmbientComponents.Num(), DeactivatedComponents.IsEmpty());
 	}
 	else
 	{
 		check(ActivatedSFXComponents.Contains(NewAudio) == false);
 		ActivatedSFXComponents.Add(NewAudio, Volume);
 		NewVolume *= SFXVolume;
-		LOGV(Warning, TEXT("Play 2D Internal(SFX), Actvated : %d, Deactivated Empty? : %d"), ActivatedSFXComponents.Num(), DeactivatedComponents.IsEmpty());
+		LOGV(Log, TEXT("Play 2D Internal(SFX), Actvated : %d, Deactivated Empty? : %d"), ActivatedSFXComponents.Num(), DeactivatedComponents.IsEmpty());
 	}
 
 	NewAudio->SetSound(SoundAsset);
@@ -449,7 +452,7 @@ int32 USoundSubsystem::Play3DInternal(USoundBase* SoundAsset, const FVector& Pos
 	check(ActivatedSFXComponents.Contains(NewAudio) == false);
 	ActivatedSFXComponents.Add(NewAudio, Volume);
 	NewVolume *= SFXVolume;
-	LOGV(Warning, TEXT("Play 3D Internal, Actvated : %d, Deactivated Empty? : %d"), ActivatedSFXComponents.Num(), DeactivatedComponents.IsEmpty());
+	LOGV(Log, TEXT("Play 3D Internal, Actvated : %d, Deactivated Empty? : %d"), ActivatedSFXComponents.Num(), DeactivatedComponents.IsEmpty());
 
 	NewAudio->SetSound(SoundAsset);
 	NewAudio->SetVolumeMultiplier(NewVolume);
@@ -457,13 +460,13 @@ int32 USoundSubsystem::Play3DInternal(USoundBase* SoundAsset, const FVector& Pos
 	NewAudio->bAllowSpatialization = true;
 	NewAudio->SetUISound(false);
 	NewAudio->SetWorldLocation(Position);
-	LOGV(Warning, TEXT("Located to : %s"), *Position.ToString());
+	LOGV(Log, TEXT("Located to : %s"), *Position.ToString());
 
 	if (AttachComp)
 	{
 		FAttachmentTransformRules Rule(EAttachmentRule::KeepRelative, false);
 		NewAudio->AttachToComponent(AttachComp, Rule);
-		LOGV(Warning, TEXT("Attached to : %s"), *AttachComp->GetName());
+		LOGV(Log, TEXT("Attached to : %s"), *AttachComp->GetName());
 	}
 
 	return PlayAudio(NewAudio, bShouldUseFadeIn, FadeInDuration, FadeInCurve);
@@ -606,6 +609,10 @@ int32 USoundSubsystem::CreateNewId()
 void USoundSubsystem::OnWorldTearDown(UWorld* World)
 {
 	LOGV(Log, TEXT("World is Tearing Down"));
+
+	StopAllBGM();
+	StopAllAmbient();
+	StopAllSFX();
 	Init(0);
 }
 


### PR DESCRIPTION


---
### 결과창 버그
- NetCulling때문에 플레이어간 거리가 너무 멀 경우 결과창이 제대로 로드 되지 않는 현상 수정
- 결과창 뜨기 전에 동기화 강제하고 1초 후 결과창 띄움 ### 사운드 버그
- 여전히 간헐적으로 맵이 넘어갈 때 이전에 실행되었던 사운드가 한꺼번에 실행 되는 현상이 있었음
- 맵 이동시 모든 사운드를 정지시키고 이동함.

###  인게임 중에는 참여 불가, 4인 초과 참여 불가 설정
- PreLogin때 InGameMode일 경우 참여 막음
- PreLogin때 CampGameMode일 경우 4인이라면 참여를 막음

### 기타
- 일부 로그 verbosity Log로 변경
---
