### PR TITLE
BugFix: Host에서 랜턴이 캐릭터를 가리는 현상 수정

### DIFF
--- a/Source/AbyssDiverUnderWorld/Character/ADSpectatorPawn.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/ADSpectatorPawn.cpp
@@ -105,7 +105,8 @@ void AADSpectatorPawn::OnTargetViewChanged(AActor* NewViewTarget)
 		PrevTargetCharacter->OnEndSpectated();
 	}
 	
-	if (NewViewTarget && NewViewTarget->IsA(AUnderwaterCharacter::StaticClass()))
+	if (NewViewTarget && NewViewTarget->IsA(AUnderwaterCharacter::StaticClass())
+		&& GetController()->GetPawn() != nullptr) // 게임 입장 시의 Spectator 상태이고 Character Pawn과 동시에 존재한다. 이 상황은 관전이 아니므로 무시한다.
 	{
 		if (AUnderwaterCharacter* UnderwaterCharacter = Cast<AUnderwaterCharacter>(NewViewTarget))
 		{


### PR DESCRIPTION
---

## 📝 작업 상세 내용
<!-- 어떤 기능을 추가/수정했는지 상세히 기술해주세요 -->
BugFix: Host에서 랜턴이 캐릭터를 가리는 현상 수정
Host에서 게임 시작 시에 Spectate Pawn과 Character Pawn이 공존해서 관전 종료 시점이 적용되고 있던 오류 수정
현재 에디터에서 리슨 서버 실행이 안 되서 Guest에서의 확인은 못해 봤습니다.

---
