### PR TITLE
BugFix: 관전 시에 자신의 시체 시각적 요소 수정

### DIFF
--- a/Source/AbyssDiverUnderWorld/Character/PlayerComponent/NameWidgetComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/PlayerComponent/NameWidgetComponent.cpp
@@ -36,6 +36,11 @@ void UNameWidgetComponent::BeginPlay()
 			NameWidget->SetNameText(NameText);
 		}
 	}
+
+	if (UUserWidget* UserWidget = GetUserWidgetObject())
+	{
+		UserWidget->SetVisibility(bIsVisible ? ESlateVisibility::Visible : ESlateVisibility::Collapsed);
+	}
 }
 
 void UNameWidgetComponent::TickComponent(float DeltaTime, ELevelTick TickType,

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
@@ -366,11 +366,11 @@ void AUnderwaterCharacter::PossessedBy(AController* NewController)
 	if (AADPlayerState* ADPlayerState = GetPlayerState<AADPlayerState>())
 	{
 		InitFromPlayerState(ADPlayerState);
+		NameWidgetComponent->SetNameText(ADPlayerState->GetPlayerNickname());
+		UE_LOG(LogAbyssDiverCharacter, Display, TEXT("Set Player Nick Name On Possess : %s"), *ADPlayerState->GetPlayerNickname());
 		if (!IsLocallyControlled())
 		{
-			NameWidgetComponent->SetNameText(ADPlayerState->GetPlayerNickname());
 			NameWidgetComponent->SetEnable(true);
-			UE_LOG(LogAbyssDiverCharacter, Display, TEXT("Set Player Nick Name On Possess : %s"), *ADPlayerState->GetPlayerNickname());
 		}
 
 		// Possess는 Authority 상황에서 호출되므로 Server 로직만 작성하면 된다.
@@ -426,11 +426,11 @@ void AUnderwaterCharacter::OnRep_PlayerState()
 		if (AADPlayerState* ADPlayerState = Cast<AADPlayerState>(CurrentPlayerState))
 		{
 			InitFromPlayerState(ADPlayerState);
+			NameWidgetComponent->SetNameText(ADPlayerState->GetPlayerNickname());
+			UE_LOG(LogAbyssDiverCharacter, Display, TEXT("Set Player Nick Name On Rep : %s"), *ADPlayerState->GetPlayerNickname());
 			if (!IsLocallyControlled())
 			{
-				NameWidgetComponent->SetNameText(ADPlayerState->GetPlayerNickname());
 				NameWidgetComponent->SetEnable(true);
-				UE_LOG(LogAbyssDiverCharacter, Display, TEXT("Set Player Nick Name On Rep : %s"), *ADPlayerState->GetPlayerNickname());
 			}
 		}
 		else
@@ -882,11 +882,13 @@ void AUnderwaterCharacter::OnRep_InCombat()
 void AUnderwaterCharacter::OnSpectated()
 {
 	SetMeshFirstPersonSetting(true);
+	NameWidgetComponent->SetEnable(false);
 }
 
 void AUnderwaterCharacter::OnEndSpectated()
 {
 	SetMeshFirstPersonSetting(false);
+	NameWidgetComponent->SetEnable(true);
 }
 
 void AUnderwaterCharacter::OnMoveSpeedChanged(float NewMoveSpeed)
@@ -1515,6 +1517,12 @@ void AUnderwaterCharacter::OnLeavePawn()
 	}
 
 	SetMeshFirstPersonSetting(false);
+
+	if (RadarObject)
+	{
+		RadarObject->Destroy();
+	}
+	NameWidgetComponent->SetEnable(true);
 }
 
 void AUnderwaterCharacter::RequestToggleRadar()

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.h
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.h
@@ -992,7 +992,7 @@ private:
 	UPROPERTY(EditDefaultsOnly, Category = "Character|Radar", meta = (AllowPrivateAccess = "true"))
 	TSubclassOf<class ARadar> RadarClass;
 
-	/** 생성한 레이더 인스턴스 */
+	/** 생성한 레이더 인스턴스. 레이더는 Replicate 되지 않고 각각의 Local에서 작동한다. */
 	UPROPERTY()
 	TObjectPtr<class ARadar> RadarObject;
 


### PR DESCRIPTION
---

## 📝 작업 상세 내용
<!-- 어떤 기능을 추가/수정했는지 상세히 기술해주세요 -->
- Radar : 자신의 레이더를 파괴해서 시각적으로 보이지 않게 수정
- NameWidget : 관전 중인 대상의 Name Widget 비활성화, 시체로 전환 시에 Name Widget 활성화

---
