### PR TITLE
🎉 add Radar 2D

### DIFF
--- a/Content/_AbyssDiver/Blueprints/Framework/BP_ADPlayerController.uasset
+++ b/Content/_AbyssDiver/Blueprints/Framework/BP_ADPlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a57bc125385064dffc1c5b811c84d52aceb83e953f52aec6aa005a120a4a3d28
-size 87143
+oid sha256:f3c743920fd6f67df5d6cd0e06749f462d379c54b3d5d3214a3fff9ac8664264
+size 87361

--- a/Content/_AbyssDiver/Blueprints/UI/InGameUI/WBP_Radar2D.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/InGameUI/WBP_Radar2D.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81b104bd2430bd07f74d4c4e6ccbc0c2a3a861da3e25bd59e3717bd1a368c116
+size 33620

--- a/Content/_AbyssDiver/Blueprints/UI/InGameUI/WBP_RadarReturn.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/InGameUI/WBP_RadarReturn.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d338aee2e21f8e46e97a84f47ee42cfc10b1e8c30b51e969991edb279d61a42
+size 26306

--- a/Content/_AbyssDiver/Images/M_SciFi_Octopuse_Body_Skin1.uasset
+++ b/Content/_AbyssDiver/Images/M_SciFi_Octopuse_Body_Skin1.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32ed13604f3f3b6a2640eaf71c77dc36532cb9baa860f39825f4d0b6b0bec470
-size 26608

--- a/Content/_AbyssDiver/Materials/RadarMaterials/M_Basic_Glow2D.uasset
+++ b/Content/_AbyssDiver/Materials/RadarMaterials/M_Basic_Glow2D.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f34c0888d0879f5200dc913dff89dc42e0b031387b7fec5df2b9347b5e2c4e28
+size 32965

--- a/Content/_AbyssDiver/Materials/RadarMaterials/M_Fresnel_Glow2D.uasset
+++ b/Content/_AbyssDiver/Materials/RadarMaterials/M_Fresnel_Glow2D.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f13a0deb99c060f49630397c415113443e827d345b0c425a33c2d8a6c6366c91
+size 60978

--- a/Content/_AbyssDiver/Materials/RadarMaterials/M_Fresnel_Glow2D_Circle.uasset
+++ b/Content/_AbyssDiver/Materials/RadarMaterials/M_Fresnel_Glow2D_Circle.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b645929712bbfd4747e7f7bce7ed03b43ca3ef28a95573a03450725143588f20
+size 33995

--- a/Source/AbyssDiverUnderWorld/Character/PlayerComponent/PlayerHUDComponent.h
+++ b/Source/AbyssDiverUnderWorld/Character/PlayerComponent/PlayerHUDComponent.h
@@ -23,6 +23,7 @@ protected:
 #pragma region Method
     
 public:
+
     UFUNCTION(Client, Reliable)
     void C_ShowResultScreen();
     void C_ShowResultScreen_Implementation();
@@ -75,6 +76,8 @@ public:
 
     /** 위젯을 보이게 한다. */
     void ShowHudWidget();
+
+    void SetActiveRadarWidget(bool bShouldActivate);
     
 protected:
     
@@ -134,7 +137,14 @@ private:
     UPROPERTY()
     TObjectPtr<class USpectatorHUDWidget> SpectatorHUDWidget;
     
-    
+    /** 레이더 HUD 위젯 클래스 */
+    UPROPERTY(EditDefaultsOnly, Category = UI, meta = (AllowPrivateAccess = "true"))
+    TSubclassOf<class URadar2DWidget> Radar2DWidgetClass;
+
+    /** 레이더 HUD 위젯 인스턴스 */
+    UPROPERTY()
+    TObjectPtr<class URadar2DWidget> Radar2DWidget;
+
 #pragma endregion
 
 #pragma region Getter Setter

--- a/Source/AbyssDiverUnderWorld/Character/PlayerComponent/UnderwaterEffectComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/PlayerComponent/UnderwaterEffectComponent.cpp
@@ -10,6 +10,8 @@
 #include "Logging/LogMacros.h"
 #include "Subsystems/SoundSubsystem.h"
 
+#include "Kismet/GameplayStatics.h"
+
 UUnderwaterEffectComponent::UUnderwaterEffectComponent()
 {
 	PrimaryComponentTick.bCanEverTick = true;

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
@@ -27,6 +27,8 @@
 #include "Interactable/Item/Component/EquipUseComponent.h"
 #include "Interactable/OtherActors/Radars/Radar.h"
 #include "Interactable/OtherActors/Radars/RadarReturnComponent.h"
+#include "Interactable/OtherActors/Radars/RadarReturn2DComponent.h"
+#include "Interactable/OtherActors/Radars/Radar2DComponent.h"
 #include "Inventory/ADInventoryComponent.h"
 #include "Net/UnrealNetwork.h"
 #include "Shops/ShopInteractionComponent.h"
@@ -197,10 +199,14 @@ AUnderwaterCharacter::AUnderwaterCharacter()
 	bIsAttackedByEyeStalker = false;
 
 	PostProcessSettingComponent = CreateDefaultSubobject<UPostProcessSettingComponent>(TEXT("PostProcessSettingComponent"));
+	RadarComponent = CreateDefaultSubobject<URadar2DComponent>(TEXT("RadarComponent"));
 
 	GetMesh()->SetLightingChannels(false, true, true);
 
 	ResurrectSFX = ESFX::Resurrection;
+
+	RadarReturn2DComponent->SetReturnScale(0.7f);
+	RadarReturn2DComponent->SetReturnForceType(EReturnForceType::Friendly);
 }
 
 void AUnderwaterCharacter::BeginPlay()
@@ -2246,7 +2252,25 @@ void AUnderwaterCharacter::Radar(const FInputActionValue& InputActionValue)
 	{
 		return;
 	}
-	RequestToggleRadar();
+	
+	UWorld* World = GetWorld();
+	if (IsValid(World) == false || World->IsInSeamlessTravel())
+	{
+		LOGV(Error, TEXT("World Is Not Valid"));
+		return;
+	}
+
+	AADPlayerController* PC = Cast<AADPlayerController>(World->GetFirstPlayerController());
+	if (PC == nullptr)
+	{
+		LOGV(Error, TEXT("PlayerController Is Not Valid"));
+		return;
+	}
+
+	bIsRadarOn = (bIsRadarOn == false);
+
+	PC->SetActiveRadarWidget(bIsRadarOn);
+	//RequestToggleRadar();
 }
 
 void AUnderwaterCharacter::EquipSlot1(const FInputActionValue& InputActionValue)

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.cpp
@@ -207,6 +207,7 @@ AUnderwaterCharacter::AUnderwaterCharacter()
 
 	RadarReturn2DComponent->SetReturnScale(0.7f);
 	RadarReturn2DComponent->SetReturnForceType(EReturnForceType::Friendly);
+	RadarReturn2DComponent->SetAlwaysDisplay(true);
 }
 
 void AUnderwaterCharacter::BeginPlay()

--- a/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.h
+++ b/Source/AbyssDiverUnderWorld/Character/UnderwaterCharacter.h
@@ -87,6 +87,7 @@ enum class EPlayAnimationTarget : uint8
 };
 
 class UInputAction;
+class URadar2DComponent;
 
 UCLASS()
 class ABYSSDIVERUNDERWORLD_API AUnderwaterCharacter : public AUnitBase, public IIADInteractable
@@ -1172,6 +1173,9 @@ private:
 	UPROPERTY()
 	TObjectPtr<class UEquipRenderComponent> EquipRenderComp;
 
+	UPROPERTY(VisibleAnywhere)
+	TObjectPtr<URadar2DComponent> RadarComponent;
+
 	/** Tool 소켓 명 (1P/3P 공용) */
 	FName LaserSocketName = TEXT("Laser");
 
@@ -1264,6 +1268,8 @@ public:
 
 	/** 캐릭터의 현재 상태를 반환. Normal, Groggy, Death... */
 	FORCEINLINE UCombatEffectComponent* GetCombatEffectComponent() const { return CombatEffectComponent; }
+
+	FORCEINLINE URadar2DComponent* GetRadarComponent() const { return RadarComponent; }
 
 	/** 캐릭터의 현재 상태를 반환 */
 	FORCEINLINE ECharacterState GetCharacterState() const { return CharacterState; }

--- a/Source/AbyssDiverUnderWorld/Character/UnitBase.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UnitBase.cpp
@@ -2,6 +2,7 @@
 
 #include "StatComponent.h"
 #include "Interactable/OtherActors/Radars/RadarReturnComponent.h"
+#include "Interactable/OtherActors/Radars/RadarReturn2DComponent.h"
 #include "Subsystems/MissionSubsystem.h"
 
 AUnitBase::AUnitBase()
@@ -11,6 +12,7 @@ AUnitBase::AUnitBase()
 
 	StatComponent = CreateDefaultSubobject<UStatComponent>(TEXT("StatComponent"));
 	RadarReturnComponent = CreateDefaultSubobject<URadarReturnComponent>(TEXT("RardarReturn"));
+	RadarReturn2DComponent = CreateDefaultSubobject<URadarReturn2DComponent>(TEXT("RadarReturn2D"));
 
 	Tags.Add(FName("Radar"));
 }

--- a/Source/AbyssDiverUnderWorld/Character/UnitBase.h
+++ b/Source/AbyssDiverUnderWorld/Character/UnitBase.h
@@ -6,6 +6,7 @@
 #include "UnitBase.generated.h"
 
 class URadarReturnComponent;
+class URadarReturn2DComponent;
 
 UENUM(BlueprintType)
 enum class EUnitId : uint8
@@ -40,6 +41,8 @@ protected:
 	virtual void Destroyed() override;
 	
 #pragma region Method
+
+protected:
 	
 	virtual float TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent, class AController* EventInstigator, AActor* DamageCauser) override;
 	
@@ -47,11 +50,16 @@ protected:
 
 #pragma region Variable
 
+protected:
+
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category="Stat")
 	TObjectPtr<class UStatComponent> StatComponent;
 
-	UPROPERTY(EditAnywhere, Category = "Radar Settings")
+	UPROPERTY(VisibleAnywhere, Category = "Radar Settings")
 	TObjectPtr<URadarReturnComponent> RadarReturnComponent;
+
+	UPROPERTY(EditAnywhere, Category = "Radar Settings")
+	TObjectPtr<URadarReturn2DComponent> RadarReturn2DComponent;
 
 	UPROPERTY(EditDefaultsOnly, Category = "Id")
 	EUnitId UnitId;

--- a/Source/AbyssDiverUnderWorld/Framework/ADPlayerController.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADPlayerController.cpp
@@ -283,6 +283,17 @@ void AADPlayerController::S_KillPlayer_Implementation()
 	KillPlayer();
 }
 
+void AADPlayerController::SetActiveRadarWidget(bool bShouldActivate)
+{
+	if (IsValid(PlayerHUDComponent) == false || PlayerHUDComponent->IsBeingDestroyed() || PlayerHUDComponent->IsValidLowLevel() == false)
+	{
+		LOGV(Error, TEXT("PlayerHUDComponent Is Not Valid"));
+		return;
+	}
+
+	PlayerHUDComponent->SetActiveRadarWidget(bShouldActivate);
+}
+
 void AADPlayerController::BeginSpectatingState()
 {
 	UE_LOG(LogAbyssDiverSpectate, Display, TEXT("Begin Spectating State for %s, GetPawn : %s"), *GetName(), GetPawn() ? *GetPawn()->GetName() : TEXT("None"));

--- a/Source/AbyssDiverUnderWorld/Framework/ADPlayerController.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADPlayerController.h
@@ -97,6 +97,8 @@ public:
 	UFUNCTION(Server, Reliable)
 	void S_KillPlayer();
 	void S_KillPlayer_Implementation();
+
+	void SetActiveRadarWidget(bool bShouldActivate);
 	
 protected:
 

--- a/Source/AbyssDiverUnderWorld/Interactable/Item/ADOreRock.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/Item/ADOreRock.cpp
@@ -10,6 +10,7 @@
 #include "Components/AudioComponent.h"
 #include "Interactable/Item/Component/ADInteractableComponent.h"
 #include "Interactable/OtherActors/Radars/RadarReturnComponent.h"
+#include "Interactable/OtherActors/Radars/RadarReturn2DComponent.h"
 #include "Character/UnderwaterCharacter.h"
 #include "Framework/ADPlayerState.h"
 #include "Inventory/ADInventoryComponent.h"
@@ -30,6 +31,9 @@ AADOreRock::AADOreRock()
 
 	RadarReturnComponent = CreateDefaultSubobject<URadarReturnComponent>(TEXT("RadarReturn"));
 	RadarReturnComponent->ChangeNeutralReturnSize(0.3f);
+	
+	RadarReturn2DComponent = CreateDefaultSubobject<URadarReturn2DComponent>(TEXT("RadarReturn2D"));
+	RadarReturn2DComponent->SetReturnForceType(EReturnForceType::Neutral);
 
 	bIsHold = true;
 }

--- a/Source/AbyssDiverUnderWorld/Interactable/Item/ADOreRock.h
+++ b/Source/AbyssDiverUnderWorld/Interactable/Item/ADOreRock.h
@@ -12,6 +12,7 @@ class UNiagaraSystem;
 class UNiagaraComponent;
 class UADInteractableComponent;
 class URadarReturnComponent;
+class URadarReturn2DComponent;
 class AUnderwaterCharacter;
 class USoundSubsystem;
 
@@ -123,6 +124,9 @@ protected:
 
 	UPROPERTY(EditAnywhere, Category = "Radar Settings")
 	TObjectPtr<URadarReturnComponent> RadarReturnComponent;
+
+	UPROPERTY(EditAnywhere, Category = "Radar Settings")
+	TObjectPtr<URadarReturn2DComponent> RadarReturn2DComponent;
 
 	UPROPERTY(EditAnywhere, Category = "Mining")
 	int32 DefaultMiningStrength = 25;

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/Radar2DComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/Radar2DComponent.cpp
@@ -1,0 +1,162 @@
+#include "Interactable/OtherActors/Radars/Radar2DComponent.h"
+
+#include "Interactable/OtherActors/Radars/RadarReturn2DComponent.h"
+#include "Character/UnderwaterCharacter.h"
+#include "Interactable/Item/ADOreRock.h"
+
+#include "EngineUtils.h"
+
+URadar2DComponent::URadar2DComponent()
+{
+	PrimaryComponentTick.bCanEverTick = true;
+	SetIsReplicatedByDefault(false);
+}
+
+void URadar2DComponent::BeginPlay()
+{
+	Super::BeginPlay();
+
+	AUnderwaterCharacter* PlayerCharacter = Cast<AUnderwaterCharacter>(GetOwner());
+	if (PlayerCharacter == nullptr)
+	{
+		SetComponentTickEnabled(false);
+		return;
+	}
+
+	if (PlayerCharacter->IsLocallyControlled() == false)
+	{
+		SetComponentTickEnabled(false);
+		return;
+	}
+
+	
+	RegisterCurrentReturns();
+}
+
+void URadar2DComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+	UWorld* World = GetWorld();
+	if (IsValid(World) == false || World->IsInSeamlessTravel())
+	{
+		return;
+	}
+
+	AUnderwaterCharacter* PlayerCharacter = Cast<AUnderwaterCharacter>(GetOwner());
+	if (PlayerCharacter == nullptr)
+	{
+		return;
+	}
+
+	for (URadarReturn2DComponent* RadarReturn : CachedReturns)
+	{
+		if (IsValid(RadarReturn) == false || RadarReturn->IsBeingDestroyed() || RadarReturn->IsValidLowLevelFast() == false)
+		{
+			CachedReturnsInDetectRadius.Remove(RadarReturn);
+			continue;
+		}
+
+		AActor* OtherActor = RadarReturn->GetOwner();
+		if (IsValid(OtherActor) == false || OtherActor->IsPendingKillPending() || OtherActor->IsValidLowLevelFast() == false)
+		{
+			CachedReturnsInDetectRadius.Remove(RadarReturn);
+			continue;
+		}
+
+		if (RadarReturn->GetAlwaysDisplay())
+		{
+			CachedReturnsInDetectRadius.Add(RadarReturn);
+			continue;
+		}
+
+		float SquaredRadius = RadarDetectRadius * RadarDetectRadius;
+		float SquaredDistance = FVector::DistSquaredXY(OtherActor->GetActorLocation(), PlayerCharacter->GetActorLocation());
+		if (SquaredDistance <= SquaredRadius)
+		{
+			CachedReturnsInDetectRadius.Add(RadarReturn);
+		}
+		else
+		{
+			CachedReturnsInDetectRadius.Remove(RadarReturn);
+		}
+	}
+}
+
+void URadar2DComponent::RegisterReturnComponent(AActor* RegisteringActor)
+{
+	URadarReturn2DComponent* FoundRadarReturn = RegisteringActor->GetComponentByClass<URadarReturn2DComponent>();
+	if (FoundRadarReturn == nullptr)
+	{
+		return;
+	}
+
+	RegisterReturnComponent(FoundRadarReturn);
+}
+
+void URadar2DComponent::RegisterReturnComponent(URadarReturn2DComponent* RegisteringReturn)
+{
+	CachedReturns.Add(RegisteringReturn);
+}
+
+void URadar2DComponent::UnregisterReturnComponent(AActor* RegisteredActor)
+{
+	URadarReturn2DComponent* FoundRadarReturn = RegisteredActor->GetComponentByClass<URadarReturn2DComponent>();
+	if (FoundRadarReturn == nullptr)
+	{
+		return;
+	}
+
+	UnregisterReturnComponent(FoundRadarReturn);
+}
+
+void URadar2DComponent::UnregisterReturnComponent(URadarReturn2DComponent* RegisteredReturn)
+{
+	CachedReturns.Remove(RegisteredReturn);
+}
+
+void URadar2DComponent::RegisterCurrentReturns()
+{
+	UWorld* World = GetWorld();
+
+	if (::IsValid(World) == false && World->IsInSeamlessTravel())
+	{
+		return;
+	}
+
+	for (AActor* RadarReturnOwner : TActorRange<AActor>(World))
+	{
+		URadarReturn2DComponent* FoundRadarReturn = RadarReturnOwner->GetComponentByClass<URadarReturn2DComponent>();
+		if (FoundRadarReturn == nullptr)
+		{
+			continue;
+		}
+
+		if (HasReturnAlready(FoundRadarReturn))
+		{
+			continue;
+		}
+
+		RegisterReturnComponent(FoundRadarReturn);
+	}
+}
+
+bool URadar2DComponent::HasReturnAlready(URadarReturn2DComponent* RadarReturn)
+{
+	return CachedReturns.Contains(RadarReturn);
+}
+
+bool URadar2DComponent::IsReturnInRadius(URadarReturn2DComponent* RadarReturn)
+{
+	return CachedReturnsInDetectRadius.Contains(RadarReturn);
+}
+
+const TSet<TObjectPtr<URadarReturn2DComponent>>& URadar2DComponent::GetAllReturnsInDetectRadius() const
+{
+	return CachedReturnsInDetectRadius;
+}
+
+float URadar2DComponent::GetRadarDetectRadius() const
+{
+	return RadarDetectRadius;
+}

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/Radar2DComponent.h
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/Radar2DComponent.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+
+#include "Radar2DComponent.generated.h"
+
+class URadarReturn2DComponent;
+
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class ABYSSDIVERUNDERWORLD_API URadar2DComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+
+	URadar2DComponent();
+
+protected:
+
+	virtual void BeginPlay() override;
+	virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+#pragma region Methods
+
+public:
+
+	void RegisterReturnComponent(AActor* RegisteringActor);
+	void RegisterReturnComponent(URadarReturn2DComponent* RegisteringReturn);
+
+	void UnregisterReturnComponent(AActor* RegisteredActor);
+	void UnregisterReturnComponent(URadarReturn2DComponent* RegisteredReturn);
+
+protected:
+
+	void RegisterCurrentReturns();
+
+	bool HasReturnAlready(URadarReturn2DComponent* RadarReturn);
+	bool IsReturnInRadius(URadarReturn2DComponent* RadarReturn);
+
+#pragma endregion
+
+#pragma region Variables
+
+protected:
+
+	UPROPERTY(EditAnywhere, Category = "RadarSettings")
+	float RadarDetectRadius = 4000.0f;
+
+	UPROPERTY()
+	TSet<TObjectPtr<URadarReturn2DComponent>> CachedReturns;
+
+	UPROPERTY()
+	TSet<TObjectPtr<URadarReturn2DComponent>> CachedReturnsInDetectRadius;
+
+#pragma endregion
+
+#pragma region Getters / Setters
+
+public:
+
+	const TSet<TObjectPtr<URadarReturn2DComponent>>& GetAllReturnsInDetectRadius() const;
+	float GetRadarDetectRadius() const;
+
+#pragma endregion
+
+		
+};

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturn2DComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturn2DComponent.cpp
@@ -1,0 +1,125 @@
+﻿#include "Interactable/OtherActors/Radars/RadarReturn2DComponent.h"
+
+#include "Interactable/OtherActors/Radars/Radar2DComponent.h"
+#include "Character/PlayerComponent/PlayerHUDComponent.h"
+#include "Character/UnderwaterCharacter.h"
+
+URadarReturn2DComponent::URadarReturn2DComponent()
+{
+	PrimaryComponentTick.bCanEverTick = false;
+	SetIsReplicatedByDefault(false);
+}
+
+void URadarReturn2DComponent::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (bAlwaysIgnore)
+	{
+		return;
+	}
+	
+	// 등록하기
+	UWorld* World = GetWorld();
+	if (IsValid(World) == false || World->IsInSeamlessTravel())
+	{
+		return;
+	}
+
+	APlayerController* PC = World->GetFirstPlayerController();
+	if (IsValid(PC) == false || PC->IsPendingKillPending() || PC->IsValidLowLevel() == false)
+	{
+		return;
+	}
+
+	AUnderwaterCharacter* PlayerCharacter = Cast<AUnderwaterCharacter>(PC->GetPawn());
+	if (IsValid(PlayerCharacter) == false || PlayerCharacter->IsPendingKillPending() || PlayerCharacter->IsValidLowLevel() == false)
+	{
+		return;
+	}
+
+	URadar2DComponent* RadarComp = PlayerCharacter->GetRadarComponent();
+	if (IsValid(RadarComp) == false || RadarComp->IsBeingDestroyed() || RadarComp->IsValidLowLevel() == false)
+	{
+		return;
+	}
+
+	RadarComp->RegisterReturnComponent(this);
+}
+
+void URadarReturn2DComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	// 해제하기
+	UWorld* World = GetWorld();
+	if (IsValid(World) == false || World->IsInSeamlessTravel())
+	{
+		Super::EndPlay(EndPlayReason);
+		return;
+	}
+
+	APlayerController* PC = World->GetFirstPlayerController();
+	if (IsValid(PC) == false || PC->IsPendingKillPending() || PC->IsValidLowLevel() == false)
+	{
+		Super::EndPlay(EndPlayReason);
+		return;
+	}
+
+	AUnderwaterCharacter* PlayerCharacter = Cast<AUnderwaterCharacter>(PC->GetPawn());
+	if (IsValid(PlayerCharacter) == false || PlayerCharacter->IsPendingKillPending() || PlayerCharacter->IsValidLowLevel() == false)
+	{
+		Super::EndPlay(EndPlayReason);
+		return;
+	}
+
+	URadar2DComponent* RadarComp = PlayerCharacter->GetRadarComponent();
+	if (IsValid(RadarComp) == false || RadarComp->IsBeingDestroyed() || RadarComp->IsValidLowLevel() == false)
+	{
+		Super::EndPlay(EndPlayReason);
+		return;
+	}
+
+	RadarComp->UnregisterReturnComponent(this);
+	
+	Super::EndPlay(EndPlayReason);
+}
+
+float URadarReturn2DComponent::GetReturnScale() const
+{
+	return ReturnScale;
+}
+
+void URadarReturn2DComponent::SetReturnScale(float NewScale)
+{
+	ReturnScale = FMath::Max(0, NewScale);
+}
+
+EReturnForceType URadarReturn2DComponent::GetReturnForceType() const
+{
+	return ReturnForceType;
+}
+
+void URadarReturn2DComponent::SetReturnForceType(EReturnForceType NewReturnForceType)
+{
+	ReturnForceType = NewReturnForceType;
+}
+
+bool URadarReturn2DComponent::GetAlwaysDisplay() const
+{
+	return bAlwaysDisplay;
+}
+
+void URadarReturn2DComponent::SetAlwaysDisplay(bool bShouldAlwaysDisplay)
+{
+	bAlwaysDisplay = bShouldAlwaysDisplay;
+}
+
+bool URadarReturn2DComponent::GetAlwaysIgnore() const
+{
+	return bAlwaysIgnore;
+}
+
+void URadarReturn2DComponent::SetAlwaysIgnore(bool bShouldAlwaysIgnore)
+{
+	bAlwaysIgnore = bShouldAlwaysIgnore;
+}
+

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturn2DComponent.h
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturn2DComponent.h
@@ -1,0 +1,68 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+
+#include "RadarReturn2DComponent.generated.h"
+
+UENUM()
+enum class EReturnForceType : uint8
+{
+	Friendly,
+	Hostile,
+	Neutral
+};
+
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class ABYSSDIVERUNDERWORLD_API URadarReturn2DComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+
+	URadarReturn2DComponent();
+
+protected:
+
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+#pragma region Variables
+
+protected:
+
+	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
+	float ReturnScale = 1.0f;
+
+	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
+	EReturnForceType ReturnForceType = EReturnForceType::Hostile;
+
+	// 레이더에 항상 표시할 지 말 지 설정
+	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
+	uint8 bAlwaysDisplay : 1 = false;
+
+	// 레이더에 표시할 지 말 지 설정, true이면 bAlwaysDisplay는 무시
+	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
+	uint8 bAlwaysIgnore : 1 = false;
+
+#pragma endregion
+
+#pragma region Getters / Setters
+
+public:
+
+	float GetReturnScale() const;
+	void SetReturnScale(float NewScale);
+
+	EReturnForceType GetReturnForceType() const;
+	void SetReturnForceType(EReturnForceType NewReturnForceType);
+
+	bool GetAlwaysDisplay() const;
+	void SetAlwaysDisplay(bool bShouldAlwaysDisplay);
+
+	bool GetAlwaysIgnore() const;
+	void SetAlwaysIgnore(bool bShouldAlwaysIgnore);
+
+#pragma endregion
+
+};

--- a/Source/AbyssDiverUnderWorld/UI/RadarWidgets/Radar2DWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/UI/RadarWidgets/Radar2DWidget.cpp
@@ -1,0 +1,240 @@
+﻿#include "UI/RadarWidgets/Radar2DWidget.h"
+
+#include "AbyssDiverUnderWorld.h"
+
+#include "Interactable/OtherActors/Radars/Radar2DComponent.h"
+#include "Interactable/OtherActors/Radars/RadarReturn2DComponent.h"
+
+#include "UI/RadarWidgets/RadarReturnWidget.h"
+#include "Character/UnderwaterCharacter.h"
+
+#include "Components/Image.h"
+#include "Components/Overlay.h"
+#include "Components/OverlaySlot.h"
+#include "Components/CanvasPanelSlot.h"
+
+void URadar2DWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	if (ensureMsgf(ReturnWidgetClass, TEXT("ReturnWidgetClass가 등록되지 않았습니다.")) == false)
+	{
+		return;
+	}
+
+	if (UCanvasPanelSlot* CanvasSlot = Cast<UCanvasPanelSlot>(RadarOverlay->Slot))
+	{
+		// 레이더 오버레이는 정사각형이라 가정
+		RadarWidgetRadius = CanvasSlot->GetSize().X / 2.0f;
+	}
+}
+
+void URadar2DWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
+{
+	Super::NativeTick(MyGeometry, InDeltaTime);
+
+	UWorld* World = GetWorld();
+	if (IsValid(World) == false || World->IsInSeamlessTravel())
+	{
+		return;
+	}
+
+	APlayerController* PC = World->GetFirstPlayerController();
+	if (IsValid(PC) == false || PC->IsPendingKillPending())
+	{
+		return;
+	}
+
+	AUnderwaterCharacter* PlayerCharacter = Cast<AUnderwaterCharacter>(PC->GetPawn());
+	if (IsValid(PlayerCharacter) == false || PlayerCharacter->IsPendingKillPending())
+	{
+		return;
+	}
+
+	URadar2DComponent* Radar = PlayerCharacter->GetComponentByClass<URadar2DComponent>();
+	if (IsValid(Radar) == false || Radar->IsBeingDestroyed())
+	{
+		return;
+	}
+
+	OwnerLocation2D = FVector2D(PlayerCharacter->GetActorLocation());
+	OwnerRotation = PlayerCharacter->GetActorRotation();
+
+	const TSet<TObjectPtr<URadarReturn2DComponent>>& AvailableRadarReturns = Radar->GetAllReturnsInDetectRadius();
+	ActualRadarRadius = Radar->GetRadarDetectRadius();
+
+	for (auto It = ActivatedReturnWidgets.CreateIterator(); It; ++It)
+	{
+		if (AvailableRadarReturns.Contains(It->Key) == false)
+		{
+			DespawnReturnWidget(It->Value);
+			ActivatedReturnWidgets.Remove(It->Key);
+		}
+	}
+
+	for (URadarReturn2DComponent* RadarReturn : AvailableRadarReturns)
+	{
+		UpdateReturn(RadarReturn);
+	}
+
+	if (UCanvasPanelSlot* CanvasSlot = Cast<UCanvasPanelSlot>(RadarOverlay->Slot))
+	{
+		RadarOverlay->SetRenderTransformAngle(-OwnerRotation.Yaw - 90);
+	}
+}
+
+void URadar2DWidget::AddReturn(URadarReturn2DComponent* ReturnComponent)
+{
+	if (HasReturn(ReturnComponent))
+	{
+		return;
+	}
+
+	TObjectPtr<URadarReturnWidget> NewReturnWidget = nullptr;
+	if (DeactivatedReturnImages.Dequeue(NewReturnWidget) && IsValid(NewReturnWidget))
+	{
+		NewReturnWidget->SetVisibility(ESlateVisibility::HitTestInvisible);
+		SetProperReturnColor(ReturnComponent, NewReturnWidget);
+		ActivatedReturnWidgets.Add({ ReturnComponent, NewReturnWidget });
+	}
+	else
+	{
+		SpawnReturn(ReturnComponent);
+	}
+}
+
+void URadar2DWidget::SpawnReturn(URadarReturn2DComponent* ReturnComponent)
+{
+	if (ReturnWidgetClass == nullptr)
+	{
+		LOGV(Error, TEXT("ReturnImageClass is not set"));
+		return;
+	}
+
+	TObjectPtr<URadarReturnWidget> NewReturnWidget = CreateWidget<URadarReturnWidget>(this, ReturnWidgetClass);
+	check(NewReturnWidget);
+
+	UOverlaySlot* RadarOverlaySlot = RadarOverlay->AddChildToOverlay(NewReturnWidget);
+	if (RadarOverlaySlot == nullptr)
+	{
+		LOGV(Error, TEXT("Overlay Slot Is Not Valid"));
+		return;
+	}
+
+	RadarOverlaySlot->SetHorizontalAlignment(EHorizontalAlignment::HAlign_Center);
+	RadarOverlaySlot->SetVerticalAlignment(EVerticalAlignment::VAlign_Center);
+
+	SetReturnWidgetTransform(ReturnComponent, NewReturnWidget);
+
+	NewReturnWidget->SetVisibility(ESlateVisibility::HitTestInvisible);
+	SetProperReturnColor(ReturnComponent, NewReturnWidget);
+	ActivatedReturnWidgets.Add({ ReturnComponent, NewReturnWidget });
+}
+
+void URadar2DWidget::DespawnReturn(const URadarReturn2DComponent* ReturnComponent)
+{
+	if (HasReturn(ReturnComponent) == false)
+	{
+		return;
+	}
+
+	URadarReturnWidget* ReturnWidget = ActivatedReturnWidgets[ReturnComponent];
+	if (IsValid(ReturnWidget))
+	{
+		DespawnReturnWidget(ReturnWidget);
+	}
+
+	ActivatedReturnWidgets.Remove(ReturnComponent);
+}
+
+void URadar2DWidget::DespawnReturnWidget(URadarReturnWidget* ReturnWidget)
+{
+	DeactivatedReturnImages.Enqueue(ReturnWidget);
+	ReturnWidget->SetVisibility(ESlateVisibility::Hidden);
+}
+
+void URadar2DWidget::UpdateReturn(URadarReturn2DComponent* ReturnComponent)
+{
+	if (IsValid(ReturnComponent) == false || ReturnComponent->IsBeingDestroyed())
+	{
+		DespawnReturn(ReturnComponent);
+		return;
+	}
+
+	if (HasReturn(ReturnComponent) == false)
+	{
+		AddReturn(ReturnComponent);
+	}
+
+	URadarReturnWidget* CurrentReturnWidget = ActivatedReturnWidgets[ReturnComponent];
+	if (IsValid(CurrentReturnWidget) == false)
+	{
+		LOGV(Error, TEXT("Return Image Is Not Valid"));
+		return;
+	}
+
+	SetReturnWidgetTransform(ReturnComponent, CurrentReturnWidget);
+	
+}
+
+bool URadar2DWidget::HasReturn(const URadarReturn2DComponent* ReturnComponent)
+{
+	return ActivatedReturnWidgets.Contains(ReturnComponent);
+}
+
+void URadar2DWidget::SetProperReturnColor(URadarReturn2DComponent* ReturnComponent, URadarReturnWidget* ReturnWidget)
+{
+	if (IsValid(ReturnWidget) == false)
+	{
+		return;
+	}
+
+	EReturnForceType ReturnForceType = ReturnComponent->GetReturnForceType();
+
+	FColor ReturnColor;
+
+	switch (ReturnForceType)
+	{
+	case EReturnForceType::Friendly:
+		ReturnColor = FColor::Green;
+		break;
+	case EReturnForceType::Hostile:
+		ReturnColor = FColor::Red;
+		break;
+	case EReturnForceType::Neutral:
+		ReturnColor = FColor::White;
+		break;
+	default:
+		check(false);
+		return;
+	}
+
+	ReturnWidget->SetReturnImageColor(ReturnColor);
+}
+
+void URadar2DWidget::SetReturnWidgetTransform(URadarReturn2DComponent* ReturnComponent, URadarReturnWidget* ReturnWidget)
+{
+	if (IsValid(ReturnComponent) == false || ReturnComponent->IsBeingDestroyed())
+	{
+		return;
+	}
+
+	AActor* TargetReturn = ReturnComponent->GetOwner();
+	if (IsValid(TargetReturn) == false || TargetReturn->IsPendingKillPending())
+	{
+		return;
+	}
+
+	FVector2D ReletiveReturnPosition(TargetReturn->GetActorLocation());
+	ReletiveReturnPosition -= OwnerLocation2D;
+	FVector2D ReturnPositionInRadar = ReletiveReturnPosition * RadarWidgetRadius / ActualRadarRadius;
+
+	if (ReturnComponent->GetAlwaysDisplay() && ReturnPositionInRadar.Length() >= RadarWidgetRadius)
+	{
+		ReturnPositionInRadar.Normalize();
+		ReturnPositionInRadar *= RadarWidgetRadius;
+	}
+
+	ReturnWidget->SetRenderTranslation(ReturnPositionInRadar);
+	ReturnWidget->SetRenderScale(FVector2D(ReturnComponent->GetReturnScale()));
+}

--- a/Source/AbyssDiverUnderWorld/UI/RadarWidgets/Radar2DWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/UI/RadarWidgets/Radar2DWidget.cpp
@@ -27,6 +27,22 @@ void URadar2DWidget::NativeConstruct()
 		// 레이더 오버레이는 정사각형이라 가정
 		RadarWidgetRadius = CanvasSlot->GetSize().X / 2.0f;
 	}
+
+	ActivatedReturnWidgets.Empty();
+	DeactivatedReturnImages.Empty();
+
+	const int32 ChildCount = RadarOverlay->GetChildrenCount();
+
+	for (int32 i = 0; i < ChildCount; ++i)
+	{
+		const int32 ChildIndex = ChildCount - i - 1;
+		UWidget* Child = RadarOverlay->GetChildAt(ChildIndex);
+		if (Child->IsA<URadarReturnWidget>())
+		{
+			RadarOverlay->RemoveChildAt(ChildIndex);
+			Child->RemoveFromParent();
+		}
+	}
 }
 
 void URadar2DWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)

--- a/Source/AbyssDiverUnderWorld/UI/RadarWidgets/Radar2DWidget.h
+++ b/Source/AbyssDiverUnderWorld/UI/RadarWidgets/Radar2DWidget.h
@@ -1,0 +1,72 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+
+#include "Radar2DWidget.generated.h"
+
+class URadarReturn2DComponent;
+class UImage;
+class UOverlay;
+class URadarReturnWidget;
+
+/**
+ * 
+ */
+UCLASS()
+class ABYSSDIVERUNDERWORLD_API URadar2DWidget : public UUserWidget
+{
+	GENERATED_BODY()
+	
+protected:
+
+	virtual void NativeConstruct() override;
+	virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
+
+#pragma region Methods
+
+protected:
+
+	void AddReturn(URadarReturn2DComponent* ReturnComponent);
+	void SpawnReturn(URadarReturn2DComponent* ReturnComponent);
+	void DespawnReturn(const URadarReturn2DComponent* ReturnComponent);
+	void DespawnReturnWidget(URadarReturnWidget* ReturnWidget);
+
+	void UpdateReturn(URadarReturn2DComponent* ReturnComponent);
+	
+	bool HasReturn(const URadarReturn2DComponent* ReturnComponent);
+
+	void SetProperReturnColor(URadarReturn2DComponent* ReturnComponent, URadarReturnWidget* ReturnWidget);
+	void SetReturnWidgetTransform(URadarReturn2DComponent* ReturnComponent, URadarReturnWidget* ReturnWidget);
+
+#pragma endregion
+
+#pragma region Variables
+
+protected:
+
+	UPROPERTY(EditDefaultsOnly, Category = "Radar2DWidgetSettings")
+	TSubclassOf<URadarReturnWidget> ReturnWidgetClass;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UOverlay> RadarOverlay;
+
+	UPROPERTY()
+	TMap<TObjectPtr<URadarReturn2DComponent>, TObjectPtr<URadarReturnWidget>> ActivatedReturnWidgets;
+	TQueue<TObjectPtr<URadarReturnWidget>> DeactivatedReturnImages;
+
+	FVector2D OwnerLocation2D;
+	FRotator OwnerRotation;
+
+	float ActualRadarRadius;
+	float RadarWidgetRadius;
+
+private:
+
+	
+
+#pragma endregion
+
+
+
+};

--- a/Source/AbyssDiverUnderWorld/UI/RadarWidgets/RadarReturnWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/UI/RadarWidgets/RadarReturnWidget.cpp
@@ -1,0 +1,14 @@
+#include "UI/RadarWidgets/RadarReturnWidget.h"
+
+#include "Components/Image.h"
+#include "Components/Overlay.h"
+
+void URadarReturnWidget::SetReturnImageColor(FColor NewColor)
+{
+	if (IsValid(RadarReturnImage) == false)
+	{
+		return;
+	}
+
+	RadarReturnImage->SetColorAndOpacity(FLinearColor(NewColor));
+}

--- a/Source/AbyssDiverUnderWorld/UI/RadarWidgets/RadarReturnWidget.h
+++ b/Source/AbyssDiverUnderWorld/UI/RadarWidgets/RadarReturnWidget.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+
+#include "RadarReturnWidget.generated.h"
+
+class UOverlay;
+class UImage;
+/**
+ * 
+ */
+UCLASS()
+class ABYSSDIVERUNDERWORLD_API URadarReturnWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+protected:
+
+
+#pragma region Methods
+
+public:
+
+	void SetReturnImageColor(FColor NewColor);
+
+#pragma endregion
+
+
+#pragma region Variables
+
+protected:
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UOverlay> RadarReturnOverlay;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UImage> RadarReturnImage;
+
+#pragma endregion
+
+	
+};


### PR DESCRIPTION
---

## 📝 작업 상세 내용
### Radar2DComponent
- 모든 RadarReturn2DComponent 관리
- 플레이어에게 유요한 리턴(레이더 범위 안) 제공

### RadarReturn2DComponent
- 레이더의 대상이 되는 리턴 2d 버전
- bAlwaysDisplay : true이면 레이더에 항상 표시
- bAlwaysIgnore : true이면 레이더에서 항상 무시, bAlwaysDisplay 무효

### Radar2DWidget
- 레이더를 표시하는 위젯

### RadarReturnWidget
- 레이더 리턴을 표시하는 위젯

### PlayerHUDComponent
- Radar2DWidget 생성 및 관리

### UnderwaterEffectComponent
- 컴파일 안되서 GameplayStatics헤더 추가

### UnderwaterCharacter
- Radar2DComponent 추가
- 기존 레이더 로직은 지우지 않았음. 레이더 입력 부분만 주석 처리 해둠.

### UnitBase
- RadarReturn2DComponent 추가

### ADPlayerController
- 레이더 활성화 함수 추가

### BP_ADPlayerController
- 블루프린트에서 PlayerHUDComponent에 WBP_Radar2D 클래스를 등록해줌.

### ADOreRock
- RadarReturn2DComponent 추가, 중립으로 설정
---
### 🐛 bugfix 맵 이동시 이전 레이더 리턴 위젯 남아있는 현상 및 기타
- 레이더 AddToViweport 때마다 조기화 해줘서 해결

### 기타
- 플레이어 레이더에 항상 표시
