### PR TITLE
✨ update 저장 기본 기능, 🎉 add SaveDataSubsystem 외 저장에 필요한 클래스

### DIFF
--- a/Content/_AbyssDiver/Maps/Final/Level/Submarine_Lobby.umap
+++ b/Content/_AbyssDiver/Maps/Final/Level/Submarine_Lobby.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b360322565bf4ac271ad7f94922e0594ca497a9d744fdfdbb5049469120b24c
-size 927647
+oid sha256:71cf235e029a9842cb7afb8ea3c1799bd4c97935a3fc7aa95f9660dd1a3fe461
+size 944300

--- a/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.cpp
@@ -154,9 +154,8 @@ bool UUpgradeComponent::Upgrade(EUpgradeType UpgradeType)
 	}
 
 	int32 Index = static_cast<int32>(UpgradeType);
-	if (UpgradeGradeMap.IsValidIndex(Index))
+	if (UpgradeGradeMap.IsValidIndex(Index) && TrySetCurrentGrade(UpgradeType, UpgradeGradeMap[Index] + 1))
 	{
-		UpgradeGradeMap[Index]++;
 		OnUpgradePerformed.Broadcast(UpgradeType, UpgradeGradeMap[Index]);
 	}
 	else
@@ -166,7 +165,7 @@ bool UUpgradeComponent::Upgrade(EUpgradeType UpgradeType)
 	return true;
 }
 
-bool UUpgradeComponent::SetCurrentGrade(EUpgradeType UpgradeType, uint8 Grade)
+bool UUpgradeComponent::TrySetCurrentGrade(EUpgradeType UpgradeType, uint8 Grade)
 {
 	if (!DataTableSubsystem.IsValid())
 	{
@@ -219,5 +218,10 @@ bool UUpgradeComponent::IsMaxGrade(EUpgradeType UpgradeType) const
 	}
 	const uint8 NextGrade = UpgradeGradeMap[Index] + 1;
 	return DataTableSubsystem->GetUpgradeData(UpgradeType, NextGrade) == nullptr;
+}
+
+const TArray<uint8>& UUpgradeComponent::GetUpgradeGradeMap() const
+{
+	return UpgradeGradeMap;
 }
 

--- a/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.h
+++ b/Source/AbyssDiverUnderWorld/Character/UpgradeComponent.h
@@ -82,7 +82,7 @@ public:
 	
 	/** Upgrade Type의 Grade를 지정, 최대 레벨을 벗어날 경우 false를 반환 */
 	UFUNCTION(BlueprintCallable)
-	bool SetCurrentGrade(EUpgradeType UpgradeType, uint8 Grade);
+	bool TrySetCurrentGrade(EUpgradeType UpgradeType, uint8 Grade);
 
 	/** 현재 Type을 Upgrade하기 위한 비용을 반환, 최대 레벨일 경우 음수를 반환 */
 	UFUNCTION(BlueprintCallable)
@@ -91,6 +91,9 @@ public:
 	/** Upgrade Type이 최대 레벨인지 확인, 다음 Grade가 없으면 Max Level이다. */
 	UFUNCTION(BlueprintCallable)
 	bool IsMaxGrade(EUpgradeType UpgradeType) const;
+
+	/** 현재 Upgrade 정보를 가져온다. Type 별로 Grade를 저장하고 있고 1이 기본값이다. */
+	const TArray<uint8>& GetUpgradeGradeMap() const;
 
 protected:
 	

--- a/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.cpp
@@ -133,3 +133,8 @@ const float UADGameInstance::GetCurrentAmbientVolume() const
 {
     return GetSubsystem<USoundSubsystem>()->GetAmbientVolume();
 }
+
+const TMap<FString, int32>& UADGameInstance::GetCurrentPlayerIdMap() const
+{
+    return CurrentPlayerIdMap;
+}

--- a/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADGameInstance.h
@@ -65,8 +65,9 @@ public:
 
 	UPROPERTY(BlueprintReadWrite)
 	int32 TeamCredits;
-	 
 
+	int32 ClearCount;
+	
 	UPROPERTY(EditDefaultsOnly, Category = "ADGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.FADItemDataRow"))
 	TObjectPtr<UDataTable> ItemDataTable;
 	UPROPERTY(EditDefaultsOnly, Category = "ADGameInstance", meta = (RequiredAssetDataTags = "RowStructure=/Script/AbyssDiverUnderWorld.FADProjectileDataRow"))
@@ -137,6 +138,9 @@ public:
 
 private:
 
+	UPROPERTY()
+	TObjectPtr<UADTutorialSaveGame> TutorialSaveGameObject;
+	
 	TMap<FString, int32> CurrentPlayerIdMap;
 	TArray<bool> ValidPlayerIndexArray;
 
@@ -164,12 +168,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Input")
 	const TMap<FName, UInputAction*>& GetInputActionMap() const { return InputActionMap; }
 
+	const TMap<FString, int32>& GetCurrentPlayerIdMap() const;
+
 	UFUNCTION(BlueprintPure, Category = "SaveGame")
 	UADTutorialSaveGame* GetTutorialSaveGame() const { return TutorialSaveGameObject; }
 
 #pragma endregion
-private:
-	UPROPERTY()
-	TObjectPtr<UADTutorialSaveGame> TutorialSaveGameObject;
-
 };

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.cpp
@@ -244,22 +244,6 @@ void AADInGameMode::ReadyForTravelToCamp()
 		return;
 	}
 
-	//for (AADPlayerState* ADPlayerState : TActorRange<AADPlayerState>(GetWorld()))
-	//{
-	//	APawn* Player = ADPlayerState->GetPawn();
-	//	if (Player == nullptr || IsValid(Player) == false || Player->IsValidLowLevel() == false || Player->IsPendingKillPending())
-	//	{
-	//		LOGV(Error, TEXT("Not Valid Player, PlayeStateName : %s"), *ADPlayerState->GetName());
-	//		continue;
-	//	}
-
-	//	ADPlayerState->GetPawn()->bAlwaysRelevant = true;
-	//}
-
-	//ForceNetUpdate();
-
-	//LOGV(Log, TEXT("Releveant On"));
-
 	TimerManager.ClearTimer(SyncTimerHandle);
 	const float WaitForSync = 1.0f;
 	TimerManager.SetTimer(SyncTimerHandle, [&]()
@@ -314,6 +298,11 @@ void AADInGameMode::TravelToCamp()
 					LOGV(Error, TEXT("LevelLoad is empty"));
 					return;
 				}
+				
+				if (bWasGameOver == false)
+				{
+					ADInGameState->SetClearCount(ADInGameState->GetClearCount() + 1);
+				}
 
 				ADInGameState->SendDataToGameInstance();
 				//input spot level name
@@ -350,7 +339,6 @@ void AADInGameMode::BindDelegate(AUnderwaterCharacter* PlayerCharacter)
 		return;
 	}
 
-	LOGV(Error, TEXT("DelegateBound"));
 	PlayerCharacter->OnCharacterStateChangedDelegate.AddDynamic(this, &AADInGameMode::OnCharacterStateChanged);
 }
 
@@ -512,6 +500,7 @@ void AADInGameMode::GameOver()
 
 #endif
 
+	bWasGameOver = true;
 	ReadyForTravelToCamp();
 	
 	for (AADPlayerController* PC : TActorRange<AADPlayerController>(GetWorld()))

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameMode.h
@@ -107,6 +107,8 @@ private:
 
 	TArray<EPlayerAliveInfo> PlayerAliveInfos;
 
+	uint8 bWasGameOver : 1 = false;
+
 #pragma endregion
 
 public:

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameState.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameState.cpp
@@ -218,6 +218,7 @@ void AADInGameState::SendDataToGameInstance()
 	{
 		ADGameInstance->SelectedLevelName = SelectedLevelName;
 		ADGameInstance->TeamCredits = TeamCredits;
+		ADGameInstance->ClearCount = ClearCount;
 	}
 
 	LOGVN(Error, TEXT("SelectedLevelName: %d / TeamCredits: %d"), SelectedLevelName, TeamCredits);
@@ -345,6 +346,7 @@ void AADInGameState::ReceiveDataFromGameInstance()
 	{
 		SelectedLevelName = ADGameInstance->SelectedLevelName;
 		TeamCredits = ADGameInstance->TeamCredits;
+		ClearCount = ADGameInstance->ClearCount;
 	}
 }
 
@@ -399,6 +401,16 @@ UPlayerHUDComponent* AADInGameState::GetPlayerHudComponent()
 
 	UPlayerHUDComponent* HudComp = PC->GetPlayerHUDComponent();
 	return HudComp;
+}
+
+int32 AADInGameState::GetClearCount() const
+{
+	return ClearCount;
+}
+
+void AADInGameState::SetClearCount(int32 NewClearCount)
+{
+	ClearCount = FMath::Max(ClearCount, 0);
 }
 
 FString AADInGameState::GetMapDisplayName() const

--- a/Source/AbyssDiverUnderWorld/Framework/ADInGameState.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADInGameState.h
@@ -176,6 +176,8 @@ protected:
 	UPROPERTY(Replicated)
 	FActivatedMissionInfoList ActivatedMissionList;
 
+	int32 ClearCount = 0;
+
 private:
 
 #pragma endregion
@@ -237,6 +239,9 @@ public:
 	}
 
 	class UPlayerHUDComponent* GetPlayerHudComponent();
+
+	int32 GetClearCount() const;
+	void SetClearCount(int32 NewClearCount);
 
 #pragma endregion
 

--- a/Source/AbyssDiverUnderWorld/SaveData/CoopData/CoopSessionSaveGame.cpp
+++ b/Source/AbyssDiverUnderWorld/SaveData/CoopData/CoopSessionSaveGame.cpp
@@ -1,0 +1,11 @@
+#include "SaveData/CoopData/CoopSessionSaveGame.h"
+
+const FCoopSessionSaveData& UCoopSessionSaveGame::GetSaveData() const
+{
+	return SessionSaveData;
+}
+
+void UCoopSessionSaveGame::SetSaveData(const FCoopSessionSaveData& InSessionSaveData)
+{
+	SessionSaveData = InSessionSaveData;
+}

--- a/Source/AbyssDiverUnderWorld/SaveData/CoopData/CoopSessionSaveGame.h
+++ b/Source/AbyssDiverUnderWorld/SaveData/CoopData/CoopSessionSaveGame.h
@@ -1,0 +1,102 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/SaveGame.h"
+
+#include "Container/FStructContainer.h"
+
+#include "CoopSessionSaveGame.generated.h"
+
+struct FItemData;
+
+USTRUCT()
+struct FPlayerProgressData
+{
+	GENERATED_BODY()
+
+public:
+
+	FPlayerProgressData()
+	{
+
+	}
+
+	FPlayerProgressData(const FString& InPlayerNetId, const TArray<FItemData>& InItemDataList,const  TArray<uint8>& InUpgradeGradeMap)
+	{
+		PlayerNetId = InPlayerNetId;
+		ItemDataList = InItemDataList;
+		UpgradeGradeMap = InUpgradeGradeMap;
+	}
+
+	UPROPERTY()
+	FString PlayerNetId;
+
+	// 인벤토리 아이템 정보
+	UPROPERTY()
+	TArray<FItemData> ItemDataList;
+
+	// 업그레이드 정보
+	UPROPERTY()
+	TArray<uint8> UpgradeGradeMap;
+
+};
+
+USTRUCT()
+struct FCoopSessionSaveData
+{
+	GENERATED_BODY()
+
+public:
+
+	FCoopSessionSaveData()
+	{
+
+	}
+
+	FCoopSessionSaveData(const TArray<FPlayerProgressData>& InPlayerProgressDataList, int32 InClearCount, int32 InTotalMoney, const FString& InSaveDataName)
+	{
+		PlayerProgressDataList = InPlayerProgressDataList;
+		ClearCount = InClearCount;
+		TotalMoney = InTotalMoney;
+		SaveDataName = InSaveDataName;
+	}
+
+	UPROPERTY()
+	TArray<FPlayerProgressData> PlayerProgressDataList;
+
+	UPROPERTY()
+	int32 ClearCount = 0;
+
+	UPROPERTY()
+	int32 TotalMoney = 0;
+
+	UPROPERTY()
+	FString SaveDataName = "";
+};
+
+/**
+ * 
+ */
+UCLASS()
+class ABYSSDIVERUNDERWORLD_API UCoopSessionSaveGame : public USaveGame
+{
+	GENERATED_BODY()
+
+#pragma region Variables
+
+private:
+
+	UPROPERTY()
+	FCoopSessionSaveData SessionSaveData;
+
+#pragma endregion
+
+#pragma region Getter / Setter
+	
+public:
+
+	const FCoopSessionSaveData& GetSaveData() const;
+	void SetSaveData(const FCoopSessionSaveData& InSessionSaveData);
+
+#pragma endregion
+};

--- a/Source/AbyssDiverUnderWorld/SaveData/CoopData/SavedSessionInfoSaveGame.cpp
+++ b/Source/AbyssDiverUnderWorld/SaveData/CoopData/SavedSessionInfoSaveGame.cpp
@@ -1,0 +1,11 @@
+#include "SaveData/CoopData/SavedSessionInfoSaveGame.h"
+
+void USavedSessionInfoSaveGame::AddSessionInfo(const FString& SavedSlotName, const FSavedSessionInfo& SessionInfo)
+{
+	SavedSessionInfos.Add({ SavedSlotName, SessionInfo });
+}
+
+void USavedSessionInfoSaveGame::RemoveSessionInfo(const FString& SavedSlotName)
+{
+	SavedSessionInfos.Remove(SavedSlotName);
+}

--- a/Source/AbyssDiverUnderWorld/SaveData/CoopData/SavedSessionInfoSaveGame.h
+++ b/Source/AbyssDiverUnderWorld/SaveData/CoopData/SavedSessionInfoSaveGame.h
@@ -1,0 +1,68 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/SaveGame.h"
+
+#include "SavedSessionInfoSaveGame.generated.h"
+
+USTRUCT()
+struct FSavedSessionInfo
+{
+	GENERATED_BODY()
+
+public:
+
+	FSavedSessionInfo()
+	{
+
+	}
+
+	FSavedSessionInfo(const FString& InSaveName)
+	{
+		SaveName = InSaveName;
+
+		const FDateTime Now = FDateTime::UtcNow();
+		SavedUnixTime = Now.ToUnixTimestamp();
+
+	}
+
+	UPROPERTY()
+	FString SaveName;
+
+	UPROPERTY()
+	int64 SavedUnixTime;
+
+	bool operator<(const FSavedSessionInfo& Other)
+	{
+		return SavedUnixTime < Other.SavedUnixTime;
+	}
+};
+
+/**
+ * 
+ */
+UCLASS()
+class ABYSSDIVERUNDERWORLD_API USavedSessionInfoSaveGame : public USaveGame
+{
+	GENERATED_BODY()
+
+#pragma region Methods
+
+public:
+
+	void AddSessionInfo(const FString& SavedSlotName, const FSavedSessionInfo& SessionInfo);
+	void RemoveSessionInfo(const FString& SavedSlotName);
+
+
+#pragma endregion
+
+#pragma region Variables
+
+public:
+
+	// SavedSlotName, SessionInfo
+	UPROPERTY()
+	TMap<FString, FSavedSessionInfo> SavedSessionInfos;
+
+#pragma endregion
+};

--- a/Source/AbyssDiverUnderWorld/Subsystems/SaveDataSubsystem.cpp
+++ b/Source/AbyssDiverUnderWorld/Subsystems/SaveDataSubsystem.cpp
@@ -1,0 +1,587 @@
+﻿#include "Subsystems/SaveDataSubsystem.h"
+
+#include "AbyssDiverUnderWorld.h"
+
+#include "SaveData/CoopData/CoopSessionSaveGame.h"
+#include "SaveData/CoopData/SavedSessionInfoSaveGame.h"
+
+#include "Framework/ADCampGameMode.h"
+#include "Framework/ADGameInstance.h"
+#include "Framework/ADInGameState.h"
+#include "Framework/ADPlayerState.h"
+
+#include "Inventory/ADInventoryComponent.h"
+#include "Character/UpgradeComponent.h"
+
+#include "Kismet/GameplayStatics.h"
+
+const FString USaveDataSubsystem::SavedSessionInfoSlotName = TEXT("SavedSessionInfo");
+const FString USaveDataSubsystem::SaveSlotNamePrefix = TEXT("SavedSession_");
+
+void USaveDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+
+	AsyncLoadSavedGameListInfo();
+}
+
+void USaveDataSubsystem::AsyncSaveCurrentGame()
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	const FDateTime Now = FDateTime::Now();
+	const FString SaveGameName = Now.ToString(TEXT("[%Y-%m-%d %H:%M:%S] ")) + TEXT("Auto Saved");
+	AsyncSaveCurrentGame(SaveGameName, false);
+}
+
+void USaveDataSubsystem::AsyncSaveCurrentGame(const FString& SaveGameName, bool bShouldOverwrite)
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	UWorld* World = GetWorld();
+	if (IsValid(World) == false || World->IsInSeamlessTravel())
+	{
+		return;
+	}
+
+	/*
+	* 저장해야 할 것
+	* PlayerNetId - UADGameInstance
+	* Inventory - PlayerState
+	* Upgrade - PlayerState
+	* ClearCount - ADInGameState
+	* TotalMoney - ADInGameState(TeamCredits)
+	* SaveDataName - Param
+	*/
+
+	UADGameInstance* GI = Cast<UADGameInstance>(GetGameInstance());
+	if (GI == nullptr)
+	{
+		PrintLogWithScreen(TEXT("Fail to Save Game, GameInstance is not valid"));
+		return;
+	}
+
+	AADInGameState* GS = World->GetGameState<AADInGameState>();
+	if (GS == nullptr)
+	{
+		PrintLogWithScreen(TEXT("Fail to Save Game, GameState is not valid"));
+		return;
+	}
+	
+	const TMap<FString, int32>& CurrentPlayerIdMap = GI->GetCurrentPlayerIdMap();
+	const int32 PlayerCount = CurrentPlayerIdMap.Num();
+	const int32 MaxPlayerCount = 4;
+	if (PlayerCount > MaxPlayerCount)
+	{
+		PrintLogWithScreen(FString::Printf(TEXT("Fail to Save Game, Weird Player Count : %d"), PlayerCount));
+		return;
+	}
+
+	TArray<FPlayerProgressData> PlayerProgressDataList;
+
+	for (const TPair<FString, int32>& NetIdPlayerIdPair : CurrentPlayerIdMap)
+	{
+		const int32 PlayerId = NetIdPlayerIdPair.Value;
+
+		AADPlayerState* PS = Cast<AADPlayerState>(UGameplayStatics::GetPlayerState(World, PlayerId));
+		if (PS == nullptr)
+		{
+			PrintLogWithScreen(FString::Printf(TEXT("Fail to Save Game, PlayerState is not valid, PlayerId : %d"), PlayerId));
+			return;
+		}
+
+		UADInventoryComponent* Inventory = PS->GetInventory();
+		if (IsValid(Inventory) == false || Inventory->IsBeingDestroyed())
+		{
+			PrintLogWithScreen(FString::Printf(TEXT("Fail to Save Game, InventoryComponent is not valid, PlayerId : %d"), PlayerId));
+			return;
+		}
+
+		const FInventoryList& InventoryList = Inventory->GetInventoryList();
+		
+		UUpgradeComponent* UpgradeComponent = PS->GetUpgradeComp();
+		if (IsValid(UpgradeComponent) == false || UpgradeComponent->IsBeingDestroyed())
+		{
+			PrintLogWithScreen(FString::Printf(TEXT("Fail to Save Game, UpgradeComponent is not valid, PlayerId : %d"), PlayerId));
+			return;
+		}
+
+		FPlayerProgressData PlayerProgressData
+		(
+			NetIdPlayerIdPair.Key,
+			InventoryList.Items,
+			UpgradeComponent->GetUpgradeGradeMap()
+		);
+
+		PlayerProgressDataList.Emplace(PlayerProgressData);
+	}
+
+	FCoopSessionSaveData SessionData
+	(
+		PlayerProgressDataList,
+		GS->GetClearCount(),
+		GS->GetTotalTeamCredit(),
+		SaveGameName
+	);
+
+	UCoopSessionSaveGame* SessionSaveGame = Cast<UCoopSessionSaveGame>(UGameplayStatics::CreateSaveGameObject(UCoopSessionSaveGame::StaticClass()));
+	if (SessionSaveGame == nullptr)
+	{
+		PrintLogWithScreen(TEXT("Fail to Save Game, SessionSaveGame is not valid"));
+		return;
+	}
+
+	SessionSaveGame->SetSaveData(SessionData);
+
+	const int32 SafetyNumber = 100;
+	for (int32 i = 0; i < SafetyNumber; ++i)
+	{
+		int32 RandomNumber = FMath::Rand();
+		FString NewSlotName = SaveSlotNamePrefix + FString::FromInt(RandomNumber);
+
+		if (bShouldOverwrite)
+		{
+			FAsyncSaveGameToSlotDelegate SaveDelegateWithOverwrite;
+			SaveDelegateWithOverwrite.BindUObject(this, &USaveDataSubsystem::OnSaveSessionGame);
+			UGameplayStatics::AsyncSaveGameToSlot(SessionSaveGame, NewSlotName, 0, SaveDelegateWithOverwrite);
+			LastSavedSessionGame = SessionSaveGame;
+			LastSavedGameSlotName = NewSlotName;
+
+			return;
+		}
+		else if(IsExistSavedSessionGame(NewSlotName) == false)
+		{
+			FAsyncSaveGameToSlotDelegate SaveDelegateWithoutOverwrite;
+			SaveDelegateWithoutOverwrite.BindUObject(this, &USaveDataSubsystem::OnSaveSessionGame);
+			UGameplayStatics::AsyncSaveGameToSlot(SessionSaveGame, NewSlotName, 0, SaveDelegateWithoutOverwrite);
+			LastSavedSessionGame = SessionSaveGame;
+			LastSavedGameSlotName = NewSlotName;
+
+			return;
+		}
+	}
+
+	PrintLogWithScreen(TEXT("Fail to Save Session Game. Atteption exceeded."));
+}
+
+void USaveDataSubsystem::AsyncLoadLastSavedGame()
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	if (LastSavedGameSlotName.IsEmpty())
+	{
+		PrintLogWithScreen(TEXT("LastSavedGame Is Not Exist"));
+		return;
+	}
+
+	AsyncLoadSavedGame(LastSavedGameSlotName);
+}
+
+void USaveDataSubsystem::AsyncLoadSavedGame(const FString& SavedSlotName)
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	FAsyncLoadGameFromSlotDelegate OnLoadGameDelegate;
+	OnLoadGameDelegate.BindUObject(this, &USaveDataSubsystem::OnLoadedSavedGame);
+	UGameplayStatics::AsyncLoadGameFromSlot(SavedSlotName, 0, OnLoadGameDelegate);
+}
+
+void USaveDataSubsystem::AsyncSaveSavedGameListInfo()
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	FAsyncSaveGameToSlotDelegate SaveDelegateWithoutOverwrite;
+	SaveDelegateWithoutOverwrite.BindUObject(this, &USaveDataSubsystem::OnSaveSavedGameListInfoGame);
+	UGameplayStatics::AsyncSaveGameToSlot(CachedSavedSessionInfo, SavedSessionInfoSlotName, 0, SaveDelegateWithoutOverwrite);
+}
+
+void USaveDataSubsystem::AsyncLoadSavedGameListInfo()
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	FAsyncLoadGameFromSlotDelegate OnLoadSessionInfoDelegate;
+	OnLoadSessionInfoDelegate.BindUObject(this, &USaveDataSubsystem::OnLoadedSavedGameListInfo);
+	UGameplayStatics::AsyncLoadGameFromSlot(SavedSessionInfoSlotName, 0, OnLoadSessionInfoDelegate);
+}
+
+void USaveDataSubsystem::DeleteAllSavedGame()
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	if (CachedSavedSessionInfo == nullptr)
+	{
+		PrintLogWithScreen(TEXT("Fail to Delete All Saved Game"));
+		return;
+	}
+
+	for (auto It = CachedSavedSessionInfo->SavedSessionInfos.CreateIterator(); It; ++It)
+	{
+		DeleteSavedGame(It->Key);
+	}
+}
+
+void USaveDataSubsystem::DeleteSavedGame(const FString& SavedSlotName)
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	if (CachedSavedSessionInfo == nullptr)
+	{
+		PrintLogWithScreen(TEXT("Fail to Delete Saved Game Because SavedSessionInfo is not valid"));
+		return;
+	}
+
+	if (UGameplayStatics::DeleteGameInSlot(SavedSlotName, 0) == false)
+	{
+		PrintLogWithScreen(FString::Printf(TEXT("Fail to Delete Saved Game, Slot Name : %s"), *SavedSlotName));
+	}
+
+	if (CachedSavedSessionInfo->SavedSessionInfos.Contains(SavedSlotName))
+	{
+		FString SaveFileName = CachedSavedSessionInfo->SavedSessionInfos[SavedSlotName].SaveName;
+		CachedSavedSessionInfo->SavedSessionInfos.Remove(SavedSlotName);
+		PrintLogWithScreen(FString::Printf(TEXT("%s(%s) is Deleted"), *SavedSlotName, *SaveFileName));
+	}
+	else
+	{
+		PrintLogWithScreen(FString::Printf(TEXT("%s is not cached"), *SavedSlotName));
+	}
+}
+
+void USaveDataSubsystem::DisplayAllSaves()
+{
+	LOGV(Warning, TEXT("StartDisplay"));
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	if (CachedSavedSessionInfo == nullptr)
+	{
+		return;
+	}
+
+	LOGV(Warning, TEXT("========From CachedInfo==========="));
+
+	TArray<FString> Slots;
+	for (const auto& Saved : CachedSavedSessionInfo->SavedSessionInfos)
+	{
+		LOGV(Warning, TEXT("Slot : %s, UnixTime : %d, SaveName : %s"), *Saved.Key, Saved.Value.SavedUnixTime, *Saved.Value.SaveName);
+		Slots.Add(Saved.Key);
+	}
+
+	LOGV(Warning, TEXT("========End CachedInfo==========="));
+	LOGV(Warning, TEXT("========From ActualSlot==========="));
+	for (const auto& Slot : Slots)
+	{
+		bool bIsExist = UGameplayStatics::DoesSaveGameExist(Slot, 0);
+		if (bIsExist)
+		{
+			UCoopSessionSaveGame* SavedGame = Cast<UCoopSessionSaveGame>(UGameplayStatics::LoadGameFromSlot(Slot, 0));
+			LOGV(Warning, TEXT("---------Slot : %s, SavedName : %s-----------------"), *Slot, *SavedGame->GetSaveData().SaveDataName);
+			LOGV(Warning, TEXT("ClearCount : %d, TotalMoney : %d"), SavedGame->GetSaveData().ClearCount, SavedGame->GetSaveData().TotalMoney);
+			
+			for (const auto& PlayerProgressData : SavedGame->GetSaveData().PlayerProgressDataList)
+			{
+				LOGV(Warning, TEXT("~~~~~Player %s Item Data~~~~~~~~~~"), *PlayerProgressData.PlayerNetId);
+				for (const auto& Item : PlayerProgressData.ItemDataList)
+				{
+					LOGV(Warning, TEXT("Item Name : %s"), *Item.Name.ToString());
+				}
+
+				LOGV(Warning, TEXT("~~~~~Player %s Upgrade Data~~~~~~~~~~"), *PlayerProgressData.PlayerNetId);
+				TArray<uint8> UpgradeInfos = PlayerProgressData.UpgradeGradeMap;
+				for (int32 i = 0; i < UpgradeInfos.Num(); ++i)
+				{
+					LOGV(Warning, TEXT("UpgradeType :%d, Grade : %d"), i, UpgradeInfos[i]);
+				}
+			}
+		}
+		else
+		{
+			LOGV(Warning, TEXT("- Slot %s is not exist"), *Slot);
+		}
+	}
+
+	LOGV(Warning, TEXT("========End ActualSlot==========="));
+}
+
+void USaveDataSubsystem::OnSaveSessionGame(const FString& SlotName, const int32 UserIndex, bool bIsSucceeded)
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	if (bIsSucceeded == false)
+	{
+		PrintLogWithScreen(TEXT("SessionGame Save Failed"));
+		return;
+	}
+
+	// 호스트가 아니면 저장 불가
+	if (UserIndex != 0)
+	{
+		PrintLogWithScreen(FString::Printf(TEXT("SessionGame Save Failed, Slot : %s, UserIndex : %d"), *SlotName, UserIndex));
+		return;
+	}
+
+	CachedSavedSessionInfo->SavedSessionInfos.Add({ SlotName, FSavedSessionInfo(LastSavedSessionGame->GetSaveData().SaveDataName) });
+	AsyncSaveSavedGameListInfo();
+
+	// 저장 성공 알리기
+	PrintLogWithScreen(FString::Printf(TEXT("SessionGame Save Succeeded, Slot : %s, UserIndex : %d"), *SlotName, UserIndex));
+}
+
+void USaveDataSubsystem::OnSaveSavedGameListInfoGame(const FString& SlotName, const int32 UserIndex, bool bIsSucceeded)
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	if (bIsSucceeded == false)
+	{
+		PrintLogWithScreen(TEXT("Fail to Save SavedGameListInfo"));
+		return;
+	}
+
+	// 호스트가 아니면 저장 불가
+	if (UserIndex != 0)
+	{
+		PrintLogWithScreen(FString::Printf(TEXT("Fail to Save SavedGameListInfo, Slot : %s, UserIndex : %d"), *SlotName, UserIndex));
+		return;
+	}
+
+	// 저장 리스트 갱신 완료..
+	PrintLogWithScreen(FString::Printf(TEXT("SavedGameListInfo Save Succeeded, Slot : %s, UserIndex : %d"), *SlotName, UserIndex));
+}
+
+void USaveDataSubsystem::OnLoadedSavedGame(const FString& LoadedSlotName, const int32 UserIndex, USaveGame* LoadedSavedGame)
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	// 호스트가 아니면 불러오기 불가
+	if (UserIndex != 0)
+	{
+		PrintLogWithScreen(FString::Printf(TEXT("Load Failed With Weird UserIndex : %d"), UserIndex));
+		return;
+	}
+
+	UCoopSessionSaveGame* SavedGame = Cast<UCoopSessionSaveGame>(LoadedSavedGame);
+	if (SavedGame == nullptr)
+	{
+		PrintLogWithScreen(FString::Printf(TEXT("Load Failed, Slot : %s, UserIndex : %d"), *LoadedSlotName, UserIndex));
+		return;
+	}
+
+	const FCoopSessionSaveData& SavedData = SavedGame->GetSaveData();
+	const TArray<FPlayerProgressData>& PlayerDataList = SavedData.PlayerProgressDataList;
+
+	// 로드한거 적용 필요
+	/*
+	* 적용해야 할 것
+	* PlayerNetId - UADGameInstance
+	* Inventory - PlayerState
+	* Upgrade - PlayerState
+	* ClearCount - ADInGameState
+	* TotalMoney - ADInGameState(TeamCredits)
+	*/
+
+	UWorld* World = GetWorld();
+	check(World);
+
+	AADInGameState* GS = Cast<AADInGameState>(World->GetGameState());
+	if (GS == nullptr)
+	{
+		PrintLogWithScreen(FString::Printf(TEXT("Load Failed, GameState is not valid, Slot : %s, UserIndex : %d"), *LoadedSlotName, UserIndex));
+		return;
+	}
+
+	GS->SetClearCount(SavedData.ClearCount);
+	GS->SetTotalTeamCredit(SavedData.TotalMoney);
+
+	UADGameInstance* GI = Cast<UADGameInstance>(GetGameInstance());
+	if (GI == nullptr)
+	{
+		PrintLogWithScreen(FString::Printf(TEXT("Load Failed, Gameinstance is not valid, Slot : %s, UserIndex : %d"), *LoadedSlotName, UserIndex));
+		return;
+	}
+
+	for (const FPlayerProgressData& PlayerProgressData : SavedData.PlayerProgressDataList)
+	{
+		int32 PlayerIndex = INDEX_NONE;
+		if (GI->TryGetPlayerIndex(PlayerProgressData.PlayerNetId, PlayerIndex) == false)
+		{
+			continue;
+		}
+
+		AADPlayerState* PS = Cast<AADPlayerState>(UGameplayStatics::GetPlayerState(World, PlayerIndex));
+		if (PS == nullptr)
+		{
+			PrintLogWithScreen(FString::Printf(TEXT("Fail to Get PlayerState From Player Index %d"), PlayerIndex));
+			continue;
+		}
+
+		UADInventoryComponent* InventoryComponent = PS->GetInventory();
+		if (IsValid(InventoryComponent) == false || InventoryComponent->IsBeingDestroyed())
+		{
+			PrintLogWithScreen(FString::Printf(TEXT("Fail to Get InventoryComponent From Player Index %d"), PlayerIndex));
+			continue;
+		}
+
+		UUpgradeComponent* UpgradeComponent = PS->GetUpgradeComp();
+		if (IsValid(UpgradeComponent) == false || UpgradeComponent->IsBeingDestroyed())
+		{
+			PrintLogWithScreen(FString::Printf(TEXT("Fail to Get UpgradeComponent From Player Index %d"), PlayerIndex));
+			continue;
+		}
+
+		for (const FItemData& ItemData : PlayerProgressData.ItemDataList)
+		{
+			InventoryComponent->AddInventoryItem(ItemData);
+		}
+
+		const int32 UpgradeTypeCount = PlayerProgressData.UpgradeGradeMap.Num();
+		for (int32 i = 0; i < UpgradeTypeCount; ++i)
+		{
+			EUpgradeType UpgradeType = EUpgradeType(i);
+
+			int32 Grade = PlayerProgressData.UpgradeGradeMap[i];
+			if (UpgradeComponent->TrySetCurrentGrade(UpgradeType, Grade) == false)
+			{
+				PrintLogWithScreen(FString::Printf(TEXT("Fail to Set Upgrade, UpgradeType : %d, Grade : %d"), UpgradeType, Grade));
+			}
+		}
+	}
+}
+
+void USaveDataSubsystem::OnLoadedSavedGameListInfo(const FString& LoadedSlotName, const int32 UserIndex, USaveGame* LoadedSavedGame)
+{
+	if (IsServer() == false)
+	{
+		return;
+	}
+
+	FString ResultString = "";
+
+	// 호스트가 아니면 불러오기 불가
+	if (UserIndex != 0)
+	{
+		ResultString = FString::Printf(TEXT("Load Failed With Weird UserIndex : %d"), UserIndex);
+		PrintLogWithScreen(ResultString);
+
+		return;
+	}
+
+	USavedSessionInfoSaveGame* SavedSessionInfo = Cast<USavedSessionInfoSaveGame>(LoadedSavedGame);
+	if (SavedSessionInfo == nullptr)
+	{
+		ResultString = FString::Printf(TEXT("Load Failed, Make Initial GameListInfo.. Slot : %s, UserIndex : %d"), *LoadedSlotName, UserIndex);
+		PrintLogWithScreen(ResultString);
+
+		AsyncSaveSavedGameListInfo();
+		CachedSavedSessionInfo = Cast<USavedSessionInfoSaveGame>(UGameplayStatics::CreateSaveGameObject(USavedSessionInfoSaveGame::StaticClass()));
+		if (CachedSavedSessionInfo == nullptr)
+		{
+			PrintLogWithScreen(TEXT("Fail to Init GameList"));
+		}
+		else
+		{
+			AsyncSaveSavedGameListInfo();
+		}
+
+		return;
+	}
+
+	CachedSavedSessionInfo = SavedSessionInfo;
+	ResultString = TEXT("Session Info Loaded");
+	PrintLogWithScreen(ResultString);
+	
+	int64 SavedTime = 0;
+	FString SavedSlotName = "";
+	for (const auto& SavedInfo : CachedSavedSessionInfo->SavedSessionInfos)
+	{
+		if (SavedInfo.Value.SavedUnixTime > SavedTime)
+		{
+			SavedTime = SavedInfo.Value.SavedUnixTime;
+			SavedSlotName = SavedInfo.Key;
+		}
+	}
+
+	LastSavedGameSlotName = SavedSlotName;
+}
+
+void USaveDataSubsystem::PrintLogWithScreen(const FString& LogMessage)
+{
+	LOGV(Error, TEXT("%s"), *LogMessage);
+
+	if (GEngine)
+	{
+		GEngine->AddOnScreenDebugMessage(-1, 5, FColor::Yellow, *LogMessage);
+	}
+}
+
+bool USaveDataSubsystem::IsServer() const
+{
+	UWorld* World = GetWorld();
+	if (IsValid(World) == false || World->IsInSeamlessTravel())
+	{
+		return false;
+	}
+
+	ENetMode CurrentNetMode = World->GetNetMode();
+	switch (CurrentNetMode)
+	{
+	case NM_Standalone:
+		return true;
+	case NM_DedicatedServer:
+		return true;
+	case NM_ListenServer:
+		return true;
+	case NM_Client:
+		return false;
+	case NM_MAX:
+		check(false)
+		return false;
+	default:
+		check(false);
+		return false;
+	}
+}
+
+bool USaveDataSubsystem::IsExistSavedSessionGame(const FString& SlotName)
+{
+	return CachedSavedSessionInfo->SavedSessionInfos.Contains(SlotName);
+}
+
+USavedSessionInfoSaveGame* USaveDataSubsystem::GetSavedSesssionListInfo() const
+{
+	return CachedSavedSessionInfo;
+}

--- a/Source/AbyssDiverUnderWorld/Subsystems/SaveDataSubsystem.h
+++ b/Source/AbyssDiverUnderWorld/Subsystems/SaveDataSubsystem.h
@@ -1,0 +1,99 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+
+#include "SaveDataSubsystem.generated.h"
+
+class UCoopSessionSaveGame;
+class USaveGame;
+class USavedSessionInfoSaveGame;
+
+struct FSavedSessionInfo;
+
+/**
+ * 
+ */
+UCLASS()
+class ABYSSDIVERUNDERWORLD_API USaveDataSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+protected:
+
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+
+#pragma region Methods
+
+public:
+
+	// Auto Save 전용
+	UFUNCTION(BlueprintCallable, Category = "SaveDataSubsystem")
+	void AsyncSaveCurrentGame();
+	void AsyncSaveCurrentGame(const FString& SaveGameName, bool bShouldOverwrite);
+
+	UFUNCTION(BlueprintCallable, Category = "SaveDataSubsystem")
+	void AsyncLoadLastSavedGame();
+	void AsyncLoadSavedGame(const FString& SavedSlotName);
+	
+	UFUNCTION(BlueprintCallable, Category = "SaveDataSubsystem")
+	void AsyncSaveSavedGameListInfo();
+
+	UFUNCTION(BlueprintCallable, Category = "SaveDataSubsystem")
+	void AsyncLoadSavedGameListInfo();
+
+	UFUNCTION(BlueprintCallable, Category = "SaveDataSubsystem")
+	void DeleteAllSavedGame();
+	void DeleteSavedGame(const FString& SavedSlotName);
+
+	UFUNCTION(BlueprintCallable, Category = "SaveDataSubsystem")
+	void DisplayAllSaves();
+
+private:
+
+	void OnSaveSessionGame(const FString& SlotName, const int32 UserIndex, bool bIsSucceeded);
+	void OnSaveSavedGameListInfoGame(const FString& SlotName, const int32 UserIndex, bool bIsSucceeded);
+
+	// Load에 실패시 LoadedSavedGame는 nullptr로 들어온다.
+	void OnLoadedSavedGame(const FString& LoadedSlotName, const int32 UserIndex, USaveGame* LoadedSavedGame);
+
+	// Load에 실패시 LoadedSavedGame는 nullptr로 들어온다.
+	void OnLoadedSavedGameListInfo(const FString& LoadedSlotName, const int32 UserIndex, USaveGame* LoadedSavedGame);
+
+	void PrintLogWithScreen(const FString& LogMessage);
+
+	bool IsServer() const;
+
+#pragma endregion
+
+
+#pragma region Variables
+
+protected:
+
+	UPROPERTY()
+	TObjectPtr<USavedSessionInfoSaveGame> CachedSavedSessionInfo;
+
+	UPROPERTY()
+	TObjectPtr<UCoopSessionSaveGame> LastSavedSessionGame;
+
+	FString LastSavedGameSlotName;
+
+
+	static const FString SavedSessionInfoSlotName;
+	static const FString SaveSlotNamePrefix;
+
+#pragma endregion
+
+#pragma region Getter / Setter
+
+public:
+
+	bool IsExistSavedSessionGame(const FString& SlotName);
+
+	USavedSessionInfoSaveGame* GetSavedSesssionListInfo() const;
+
+#pragma endregion
+
+	
+};


### PR DESCRIPTION


---

## 📝 작업 상세 내용
## ✨ update 저장 기본 기능
### Submarine_Lobby
- 저장 임시 기능 구현
- 키패드 0 : 현재 저장된 정보 로그 출력
- 키패드 1 : 현재 세션 정보 저장
- 키패드 2 : 가장 최근에 저장된 세션 정보 불러오기
- 키패드 3 : 저장된 세션 정보 전부 제거

### UpgradeComponent
- SetCurrentGrade -> TrySetCurrentGrade 함수 명 변경
- Upgrade : TrySetCurrentGrade 활용한 로직으로 변경
- 업그레이드 정보 Getter 추가

### ADGameInstance
- ClearCount : 게임 클리어 횟수, InGameState에서 쓸 ClearCount 임시 저장용
- TutorialSaveGameObject : 위치 옮김
- GetCurrentPlayerIdMap : 접속 중인 플레이어 NetId 가져오는 용도

### ADInGameMode
- 필요 없는 주석 삭제
- TravelToCamp : 게임 오버가 아닌 클리어로 캠프로 돌아갈 시 ClearCount 증가
- bWasGameOver : 게임 오버시 true

### ADInGameState
- ClearCount : 게임 클리어 횟수, 횟수에 따라 게임 난이도 증가 예정

---

## 🎉 add SaveDataSubsystem 외 저장에 필요한 클래스
### CoopSessionSaveGame
- 저장할 세션 데이터 클래스
- FPlayerProgressData : 각 플레이어마다 진행 정도 저장용 - NetId, Items, Upgrades
- FCoopSessionSaveData : 실질적 세션 데이터 저장용

### SavedSessionInfoSaveGame
- 이미 저장된 세션 데이터 리스트를 저장하는 용도
- FSavedSessionInfo : 각각의 저장된 세션

### SaveDataSubsystem
- 세션 저장, 불러오기, 삭제 담당
- 저장, 불러오기는 비동기로 작동
- CachedSavedSessionInfo를 통해 저장된 슬롯들 파악, 후에 UI에 표시함.
---
