### PR TITLE
튜토리얼 시작 자동화 및 진행 이벤트 조정

### DIFF
--- a/Content/_AbyssDiver/Maps/Prototypes_Test/TutorialPool.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/TutorialPool.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e29b7865e42f058695f4f616e6f485bce73bcd2f22ee83b1bcc03dd8521ca913
-size 10351945
+oid sha256:f928feb31557afc1fc38175ea1867bb1eba0c0756abcff11ddba4dce3735b97b
+size 10365835

--- a/Source/AbyssDiverUnderWorld/Framework/ADTutorialGameMode.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADTutorialGameMode.cpp
@@ -24,7 +24,7 @@ AADTutorialGameMode::AADTutorialGameMode()
 void AADTutorialGameMode::StartPlay()
 {
     Super::StartPlay();
-    SpawnNewWall(FName("TutorialWall_1"));
+    SpawnNewWall(FName("TutorialWall_1")); 
     TutorialPlayerController = Cast<AADPlayerController>(UGameplayStatics::GetPlayerController(this, 0));
 
     TArray<AActor*> TutorialActors;
@@ -37,7 +37,7 @@ void AADTutorialGameMode::StartPlay()
             Actor->SetActorHiddenInGame(true);
             if (URadarReturn2DComponent* RadarComp = Actor->FindComponentByClass<URadarReturn2DComponent>())
             {
-                RadarComp->bAlwaysIgnore = true;
+                RadarComp->SetAlwaysIgnore(true);
             }
         }
     }
@@ -51,7 +51,7 @@ void AADTutorialGameMode::StartPlay()
             Actor->SetActorHiddenInGame(true);
             if (URadarReturn2DComponent* RadarComp = Actor->FindComponentByClass<URadarReturn2DComponent>())
             {
-                RadarComp->bAlwaysIgnore = true;
+                RadarComp->SetAlwaysIgnore(true);
             }
         }
     }
@@ -65,7 +65,7 @@ void AADTutorialGameMode::StartPlay()
             Actor->SetActorHiddenInGame(true);
             if (URadarReturn2DComponent* RadarComp = Actor->FindComponentByClass<URadarReturn2DComponent>())
             {
-                RadarComp->bAlwaysIgnore = true;
+                RadarComp->SetAlwaysIgnore(true);
             }
         }
     }
@@ -79,7 +79,7 @@ void AADTutorialGameMode::StartPlay()
             Actor->SetActorHiddenInGame(true);
             if (URadarReturn2DComponent* RadarComp = Actor->FindComponentByClass<URadarReturn2DComponent>())
             {
-                RadarComp->bAlwaysIgnore = true;
+                RadarComp->SetAlwaysIgnore(true);
             }
         }
     }
@@ -92,6 +92,7 @@ void AADTutorialGameMode::StartPlay()
         false
     );
 }
+
 
 void AADTutorialGameMode::StartFirstTutorialPhase()
 {
@@ -184,7 +185,7 @@ void AADTutorialGameMode::HandlePhase_Radar()
         Rock->SetActorHiddenInGame(false);
         if (URadarReturn2DComponent* RadarComp = Rock->FindComponentByClass<URadarReturn2DComponent>())
         {
-            RadarComp->bAlwaysIgnore = false;
+            RadarComp->SetAlwaysIgnore(false);
         }
     }
     FoundActors.Empty();
@@ -195,7 +196,7 @@ void AADTutorialGameMode::HandlePhase_Radar()
         Monster->SetActorHiddenInGame(false);
         if (URadarReturn2DComponent* RadarComp = Monster->FindComponentByClass<URadarReturn2DComponent>())
         {
-            RadarComp->bAlwaysIgnore = false;
+            RadarComp->SetAlwaysIgnore(false);
         }
     }
     FoundActors.Empty();
@@ -206,7 +207,7 @@ void AADTutorialGameMode::HandlePhase_Radar()
         Friendly->SetActorHiddenInGame(false);
         if (URadarReturn2DComponent* RadarComp = Friendly->FindComponentByClass<URadarReturn2DComponent>())
         {
-            RadarComp->bAlwaysIgnore = false;
+            RadarComp->SetAlwaysIgnore(false);
         }
     }
 }

--- a/Source/AbyssDiverUnderWorld/Framework/ADTutorialGameMode.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADTutorialGameMode.cpp
@@ -12,7 +12,9 @@
 #include "Framework/ADPlayerController.h"
 #include "Engine/Light.h"
 #include "NiagaraComponent.h"
+#include "TimerManager.h"
 #include "Components/LightComponent.h" 
+#include "Interactable/OtherActors/Radars/RadarReturn2DComponent.h"
 #include "EngineUtils.h"
 
 AADTutorialGameMode::AADTutorialGameMode()
@@ -26,15 +28,17 @@ void AADTutorialGameMode::StartPlay()
     TutorialPlayerController = Cast<AADPlayerController>(UGameplayStatics::GetPlayerController(this, 0));
 
     TArray<AActor*> TutorialActors;
-    const FName RadarTag = FName("Radar");
 
     UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName("TutorialRock_D2"), TutorialActors);
     for (AActor* Actor : TutorialActors)
     {
         if (IsValid(Actor))
         {
-            Actor->Tags.Remove(RadarTag);
             Actor->SetActorHiddenInGame(true);
+            if (URadarReturn2DComponent* RadarComp = Actor->FindComponentByClass<URadarReturn2DComponent>())
+            {
+                RadarComp->bAlwaysIgnore = true;
+            }
         }
     }
     TutorialActors.Empty();
@@ -44,8 +48,11 @@ void AADTutorialGameMode::StartPlay()
     {
         if (IsValid(Actor))
         {
-            Actor->Tags.Remove(RadarTag);
-            Actor->SetActorHiddenInGame(true); 
+            Actor->SetActorHiddenInGame(true);
+            if (URadarReturn2DComponent* RadarComp = Actor->FindComponentByClass<URadarReturn2DComponent>())
+            {
+                RadarComp->bAlwaysIgnore = true;
+            }
         }
     }
     TutorialActors.Empty();
@@ -55,8 +62,11 @@ void AADTutorialGameMode::StartPlay()
     {
         if (IsValid(Actor))
         {
-            Actor->Tags.Remove(RadarTag);
-            Actor->SetActorHiddenInGame(true); 
+            Actor->SetActorHiddenInGame(true);
+            if (URadarReturn2DComponent* RadarComp = Actor->FindComponentByClass<URadarReturn2DComponent>())
+            {
+                RadarComp->bAlwaysIgnore = true;
+            }
         }
     }
     TutorialActors.Empty();
@@ -66,11 +76,26 @@ void AADTutorialGameMode::StartPlay()
     {
         if (IsValid(Actor))
         {
-            Actor->Tags.Remove(RadarTag);
-            Actor->SetActorHiddenInGame(true); 
+            Actor->SetActorHiddenInGame(true);
+            if (URadarReturn2DComponent* RadarComp = Actor->FindComponentByClass<URadarReturn2DComponent>())
+            {
+                RadarComp->bAlwaysIgnore = true;
+            }
         }
     }
-    HandleCurrentPhase();
+
+    GetWorldTimerManager().SetTimer(
+        TutorialStartTimerHandle,
+        this,
+        &AADTutorialGameMode::StartFirstTutorialPhase,
+        2.0f,
+        false
+    );
+}
+
+void AADTutorialGameMode::StartFirstTutorialPhase()
+{
+    AdvanceTutorialPhase();
 }
 
 void AADTutorialGameMode::AdvanceTutorialPhase()
@@ -151,6 +176,39 @@ void AADTutorialGameMode::HandlePhase_Radar()
     {
         Manager->StartGaugeObjective(EGaugeInteractionType::Tap, 100.f, 10.f, 0.f);
     }
+
+    TArray<AActor*> FoundActors;
+    UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName("TutorialRock_D2"), FoundActors);
+    for (AActor* Rock : FoundActors)
+    {
+        Rock->SetActorHiddenInGame(false);
+        if (URadarReturn2DComponent* RadarComp = Rock->FindComponentByClass<URadarReturn2DComponent>())
+        {
+            RadarComp->bAlwaysIgnore = false;
+        }
+    }
+    FoundActors.Empty();
+
+    UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName("TutorialMonster_D2"), FoundActors);
+    for (AActor* Monster : FoundActors)
+    {
+        Monster->SetActorHiddenInGame(false);
+        if (URadarReturn2DComponent* RadarComp = Monster->FindComponentByClass<URadarReturn2DComponent>())
+        {
+            RadarComp->bAlwaysIgnore = false;
+        }
+    }
+    FoundActors.Empty();
+
+    UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName("TutorialFriendly_D2"), FoundActors);
+    for (AActor* Friendly : FoundActors)
+    {
+        Friendly->SetActorHiddenInGame(false);
+        if (URadarReturn2DComponent* RadarComp = Friendly->FindComponentByClass<URadarReturn2DComponent>())
+        {
+            RadarComp->bAlwaysIgnore = false;
+        }
+    }
 }
 
 void AADTutorialGameMode::HandlePhase_Oxygen()
@@ -160,62 +218,41 @@ void AADTutorialGameMode::HandlePhase_Oxygen()
 
 void AADTutorialGameMode::HandlePhase_Dialogue_02()
 {
+    TArray<AActor*> ActorsToTrack;
+    UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName("TutorialMonster_D2"), ActorsToTrack);
+    for (AActor* Monster : ActorsToTrack)
+    {
+        TrackPhaseActor(Monster);
+    }
+    ActorsToTrack.Empty();
+
+    UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName("TutorialFriendly_D2"), ActorsToTrack);
+    for (AActor* Friendly : ActorsToTrack)
+    {
+        TrackPhaseActor(Friendly);
+    }
+
     if (!IndicatingTargetClass)
     {
         UE_LOG(LogTemp, Error, TEXT("IndicatingTargetClass is not set in TutorialGameMode BP."));
         return;
     }
-
     TArray<AActor*> SpawnPoints;
     UGameplayStatics::GetAllActorsWithTag(GetWorld(), DialogueTargetSpawnTag, SpawnPoints);
-    if (SpawnPoints.Num() == 0)
+    if (SpawnPoints.Num() > 0)
     {
-        UE_LOG(LogTemp, Error, TEXT("Cannot find an actor with tag '%s' to spawn the dialogue target."), *DialogueTargetSpawnTag.ToString());
-        return;
-    }
-
-    AActor* SpawnPoint = SpawnPoints[0];
-    FVector   SpawnLocation = SpawnPoint->GetActorLocation();
-    FRotator  SpawnRotation = SpawnPoint->GetActorRotation();
-
-    AIndicatingTarget* Indicator = GetWorld()->SpawnActor<AIndicatingTarget>(IndicatingTargetClass, SpawnLocation, SpawnRotation);
-    if (Indicator)
-    {
-        Indicator->SetupIndicator(nullptr, DialogueIndicatorIcon);
-
-        if (ATargetIndicatorManager* Manager = *TActorIterator<ATargetIndicatorManager>(GetWorld()))
+        AActor* SpawnPoint = SpawnPoints[0];
+        AIndicatingTarget* Indicator = GetWorld()->SpawnActor<AIndicatingTarget>(IndicatingTargetClass, SpawnPoint->GetActorTransform());
+        if (Indicator)
         {
-            Manager->RegisterNewTarget(Indicator);
+            Indicator->SetupIndicator(nullptr, DialogueIndicatorIcon);
+            if (ATargetIndicatorManager* TargetManager = *TActorIterator<ATargetIndicatorManager>(GetWorld()))
+            {
+                TargetManager->RegisterNewTarget(Indicator);
+            }
+            TrackPhaseActor(Indicator);
         }
-        TrackPhaseActor(Indicator);
     }
-
-    TArray<AActor*> FoundActors;
-    UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName("TutorialRock_D2"), FoundActors);
-    for (AActor* Rock : FoundActors)
-    {
-        Rock->SetActorHiddenInGame(false);
-        Rock->Tags.Add(FName("Radar"));
-    }
-    FoundActors.Empty();
-
-    UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName("TutorialMonster_D2"), FoundActors);
-    for (AActor* Monster : FoundActors)
-    {
-        Monster->SetActorHiddenInGame(false);
-        Monster->Tags.Add(FName("Radar"));
-        TrackPhaseActor(Monster); 
-    }
-    FoundActors.Empty();
-
-    UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName("TutorialFriendly_D2"), FoundActors);
-    for (AActor* Friendly : FoundActors)
-    {
-        Friendly->SetActorHiddenInGame(false);
-        Friendly->Tags.Add(FName("Radar"));
-        TrackPhaseActor(Friendly); 
-    }
-
 }
 
 void AADTutorialGameMode::HandlePhase_Looting()

--- a/Source/AbyssDiverUnderWorld/Framework/ADTutorialGameMode.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADTutorialGameMode.h
@@ -23,7 +23,7 @@ protected:
 
 #pragma region Method
 public:
-
+	void StartFirstTutorialPhase();
 	void AdvanceTutorialPhase();
 	void OnTypingAnimationFinished();
 	void OnPlayerItemAction(EPlayerActionTrigger ItemActionType);
@@ -65,6 +65,8 @@ private:
 
 #pragma region Variable
 protected:
+	FTimerHandle TutorialStartTimerHandle;
+
 	UPROPERTY(EditAnywhere, Category = "Tutorial")
 	TObjectPtr<UDataTable> TutorialDataTable;
 

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturn2DComponent.h
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturn2DComponent.h
@@ -28,10 +28,6 @@ protected:
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 #pragma region Variables
-public:
-	// 레이더에 표시할 지 말 지 설정, true이면 bAlwaysDisplay는 무시
-	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
-	uint8 bAlwaysIgnore : 1 = false;
 protected:
 
 	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
@@ -44,6 +40,9 @@ protected:
 	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
 	uint8 bAlwaysDisplay : 1 = false;
 
+	// 레이더에 표시할 지 말 지 설정, true이면 bAlwaysDisplay는 무시
+	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
+	uint8 bAlwaysIgnore : 1 = false;
 #pragma endregion
 
 #pragma region Getters / Setters

--- a/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturn2DComponent.h
+++ b/Source/AbyssDiverUnderWorld/Interactable/OtherActors/Radars/RadarReturn2DComponent.h
@@ -28,7 +28,10 @@ protected:
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 #pragma region Variables
-
+public:
+	// 레이더에 표시할 지 말 지 설정, true이면 bAlwaysDisplay는 무시
+	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
+	uint8 bAlwaysIgnore : 1 = false;
 protected:
 
 	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
@@ -40,10 +43,6 @@ protected:
 	// 레이더에 항상 표시할 지 말 지 설정
 	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
 	uint8 bAlwaysDisplay : 1 = false;
-
-	// 레이더에 표시할 지 말 지 설정, true이면 bAlwaysDisplay는 무시
-	UPROPERTY(EditAnywhere, Category = "RadarReturnSettings")
-	uint8 bAlwaysIgnore : 1 = false;
 
 #pragma endregion
 

--- a/Source/AbyssDiverUnderWorld/Tutorial/TutorialManager.h
+++ b/Source/AbyssDiverUnderWorld/Tutorial/TutorialManager.h
@@ -4,6 +4,7 @@
 #include "GameFramework/Actor.h"
 #include "TutorialStepData.h"
 #include "TutorialEnums.h"
+#include "Framework/ADTutorialGameMode.h"
 #include "Components/ProgressBar.h"
 #include "TutorialManager.generated.h"
 
@@ -87,6 +88,9 @@ protected:
 	TObjectPtr<UProgressBar> GaugeProgressBar;
 
 	FTimerHandle StepTimerHandle;
+
+	UPROPERTY()
+	TObjectPtr<AADTutorialGameMode> CachedGameMode;
 #pragma endregion
 
 #pragma region Getter, Setter


### PR DESCRIPTION
---

## 📝 작업 상세 내용
**튜토리얼 액터 등장 시점 조정**
- HandlePhase_Radar에 있던 관련 로직을 HandlePhase_Looting 함수로 이전하여, 'Looting' 단계의 목표와 액터의 등장을 일치시켰습니다

**게이지 미션 시작 조건 추가**
- 출력이 완료되기 전까지 게이지 관련 상호작용이 작동하지 않도록 막았습니다

**튜토리얼 시작 방식 변경 (트리거 → 타이머)**
- ATutorialTriggerZone 액터와 관련 로직을 모두 제거했습니다. 대신 **AADTutorialGameMode**의 StartPlay 함수에 2초짜리 타이머를 추가하여, 레벨 시작 후 2초가 지나면 첫 튜토리얼 단계(AdvanceTutorialPhase)가 자동으로 호출되도록 수정했습니다
---

## 📸 스크린샷 (선택)
<!-- UI, 이펙트, 레벨 디자인 등 시각적 작업 시 스크린샷 첨부 -->
<img src="경로/스크린샷.png" width="400" />

---

## 🙋 리뷰어에게 요청사항
<!-- 리뷰 시 중점적으로 봐줬으면 하는 부분 -->
- 네이밍이 적절한지 확인 부탁드립니다
- 입력 처리 방식이 괜찮은지 봐주세요

---
