### PR TITLE
인벤토리 아이템 추가 & 드래그 앤 드롭 수정 & zorder 수정

### DIFF
--- a/Content/_AbyssDiver/Blueprints/Framework/BP_ADTutorialGameMode.uasset
+++ b/Content/_AbyssDiver/Blueprints/Framework/BP_ADTutorialGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0be666478dc95b23bfee8073f6a83378e3f2231de289fe2e8138c855e89a6d71
-size 23683
+oid sha256:9e4beceb5cf72dab7f68ea2e49ea3a0374d6c5ebcb2f9e3beb4b134b522a01b8
+size 113612

--- a/Content/_AbyssDiver/DataTable/TutorialData/DT_TutorialSteps.uasset
+++ b/Content/_AbyssDiver/DataTable/TutorialData/DT_TutorialSteps.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca20fe4fb1d5ce3915f9d42e133db96f6ba307fe613c87eff9cb15d514cbdb00
-size 29634
+oid sha256:24b853a2aaeedf74ecc33f56f7db945b8c06b7526585d33d1444fbc4de2885a8
+size 28413

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/TutorialPool.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/TutorialPool.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1bf37b4764ad1ed18edbd4213c8598b78074bd0283d633bec961ac379c3dd01d
-size 10366117
+oid sha256:c9e290f970248ac655cc506e14279899b3cfdfba6fb55f9890311deb510bc912
+size 10366135

--- a/Source/AbyssDiverUnderWorld/Framework/ADTutorialGameMode.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADTutorialGameMode.h
@@ -18,10 +18,6 @@ class ABYSSDIVERUNDERWORLD_API AADTutorialGameMode : public AGameMode
 public:
 	AADTutorialGameMode();
 
-protected:
-	virtual void StartPlay() override;
-
-#pragma region Method
 public:
 	void StartFirstTutorialPhase();
 	void AdvanceTutorialPhase();
@@ -36,7 +32,15 @@ public:
 	UFUNCTION(BlueprintCallable)
 	void SpawnDownedNPC();
 
+public:
+	UFUNCTION(BlueprintPure, Category = "Tutorial")
+	bool IsTypingFinishedForCurrentPhase() const;
+
 protected:
+	virtual void StartPlay() override;
+
+	UFUNCTION(BlueprintImplementableEvent, Category = "Tutorial")
+	void OnPhaseBatteryStart();
 
 	void HandleCurrentPhase();
 	void HandlePhase_Dialogue_02();
@@ -58,16 +62,11 @@ protected:
 	void HandlePhase_Complete();
 	void HidePhaseActors();
 
-private:
-	void TrackPhaseActor(AActor* Actor) { if (IsValid(Actor)) { ActorsToShowThisPhase.Add(Actor); } }
-	void BindIndicatorToOwner(AActor* OwnerActor, AActor* IndicatorActor);
-#pragma endregion 
-
-#pragma region Variable
 protected:
-	FTimerHandle TutorialStartTimerHandle;
+	UPROPERTY(EditAnywhere, Category = "Tutorial|Debug")
+	ETutorialPhase StartPhaseOverride = ETutorialPhase::None;
 
-	UPROPERTY(EditAnywhere, Category = "Tutorial")
+	UPROPERTY(EditAnywhere, Category = "Tutorial|Data")
 	TObjectPtr<UDataTable> TutorialDataTable;
 
 	UPROPERTY(EditDefaultsOnly, Category = "Tutorial|Spawning")
@@ -94,10 +93,13 @@ protected:
 	UPROPERTY(EditDefaultsOnly, Category = "Tutorial")
 	TSubclassOf<AActor> CurrentWallClass;
 
-private:
-	bool bIsTypingFinishedForCurrentPhase = false;
-	int32 ItemsPhaseProgress;
+	FTimerHandle TutorialStartTimerHandle;
 
+private:
+	void TrackPhaseActor(AActor* Actor);
+	void BindIndicatorToOwner(AActor* OwnerActor, AActor* IndicatorActor);
+
+private:
 	UPROPERTY()
 	TObjectPtr<class AADPlayerController> TutorialPlayerController;
 
@@ -108,19 +110,12 @@ private:
 	TArray<TObjectPtr<ALight>> DisabledLights;
 
 	UPROPERTY()
-	TMap<TWeakObjectPtr<AActor>, TWeakObjectPtr<AActor>> OwnerToIndicator;
-
-	UPROPERTY()
 	TObjectPtr<AActor> ActiveCurrentWall;
 
 	UPROPERTY()
 	TObjectPtr<APostProcessVolume> TutorialPPV = nullptr;
 
-	FTimerHandle StepTimerHandle;
-#pragma endregion
-
-#pragma region Getter, Setter
-public:
-	bool IsTypingFinishedForCurrentPhase() const { return bIsTypingFinishedForCurrentPhase; }
-#pragma endregion
+	bool bIsTypingFinishedForCurrentPhase = false;
+	int32 ItemsPhaseProgress;
+	TMap<TWeakObjectPtr<AActor>, TWeakObjectPtr<AActor>> OwnerToIndicator;
 };

--- a/Source/AbyssDiverUnderWorld/Framework/ADTutorialPlayerController.cpp
+++ b/Source/AbyssDiverUnderWorld/Framework/ADTutorialPlayerController.cpp
@@ -1,3 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
 #include "Framework/ADTutorialPlayerController.h"
 #include "Character/UnderwaterCharacter.h"
 #include "EnhancedInputComponent.h"
@@ -54,11 +56,7 @@ void AADTutorialPlayerController::SetPawn(APawn* InPawn)
 				EnhancedInput->BindAction(InventoryAction, ETriggerEvent::Started, this, &AADTutorialPlayerController::OnInventoryStarted);
 				EnhancedInput->BindAction(InventoryAction, ETriggerEvent::Completed, this, &AADTutorialPlayerController::OnInventoryCompleted);
 			}
-			if (BatteryAction)
-			{
-				EnhancedInput->BindAction(BatteryAction, ETriggerEvent::Started, this, &AADTutorialPlayerController::OnBatteryStarted);
-				EnhancedInput->BindAction(BatteryAction, ETriggerEvent::Completed, this, &AADTutorialPlayerController::OnBatteryCompleted);
-			}
+
 			if (DropAction)
 			{
 				EnhancedInput->BindAction(DropAction, ETriggerEvent::Started, this, &AADTutorialPlayerController::OnDropStarted);
@@ -87,22 +85,15 @@ void AADTutorialPlayerController::SetPawn(APawn* InPawn)
 
 void AADTutorialPlayerController::CheckTutorialObjective(const FInputActionValue& Value, UInputAction* SourceAction)
 {
-	AUnderwaterCharacter* PossessedCharacter = Cast<AUnderwaterCharacter>(GetPawn());
-	if (!PossessedCharacter) return;
-
 	AADTutorialGameState* TutorialGS = GetWorld() ? GetWorld()->GetGameState<AADTutorialGameState>() : nullptr;
 	if (!TutorialGS) return;
 
 	ETutorialPhase CurrentPhase = TutorialGS->GetCurrentPhase();
 	bool bObjectiveMet = false;
 
-	if (SourceAction == InteractAction)
+	if (SourceAction == InteractAction && (CurrentPhase == ETutorialPhase::Step7_Drone || CurrentPhase == ETutorialPhase::Step15_Resurrection))
 	{
-		if (CurrentPhase == ETutorialPhase::Step7_Drone ||
-			CurrentPhase == ETutorialPhase::Step15_Resurrection )
-		{
-			bObjectiveMet = true;
-		}
+		bObjectiveMet = true;
 	}
 
 	if (bObjectiveMet)
@@ -135,9 +126,16 @@ void AADTutorialPlayerController::ReportItemAction(EPlayerActionTrigger ItemActi
 
 void AADTutorialPlayerController::OnInteractStarted(const FInputActionValue& Value)
 {
-	if (IsValid(CachedTutorialManager) && CachedTutorialManager->IsGaugeObjectiveActive())
+	if (!IsValid(CachedTutorialManager)) return;
+
+	AADTutorialGameState* GS = GetWorld()->GetGameState<AADTutorialGameState>();
+	if (GS && CachedTutorialManager->IsGaugeObjectiveActive())
 	{
-		CachedTutorialManager->NotifyInteractionStart();
+		ETutorialPhase CurrentPhase = GS->GetCurrentPhase();
+		if (CurrentPhase == ETutorialPhase::Step13_Revive)
+		{
+			CachedTutorialManager->NotifyInteractionStart();
+		}
 	}
 	else
 	{
@@ -155,9 +153,14 @@ void AADTutorialPlayerController::OnInteractCompleted(const FInputActionValue& V
 
 void AADTutorialPlayerController::OnSprintStarted(const FInputActionValue& Value)
 {
-	if (IsValid(CachedTutorialManager))
+	AADTutorialGameState* GS = GetWorld()->GetGameState<AADTutorialGameState>();
+
+	if (GS && GS->GetCurrentPhase() == ETutorialPhase::Step2_Sprint)
 	{
-		CachedTutorialManager->NotifyInteractionStart();
+		if (IsValid(CachedTutorialManager))
+		{
+			CachedTutorialManager->NotifyInteractionStart();
+		}
 	}
 }
 
@@ -171,9 +174,14 @@ void AADTutorialPlayerController::OnSprintCompleted(const FInputActionValue& Val
 
 void AADTutorialPlayerController::OnRadarStarted(const FInputActionValue& Value)
 {
-	if (IsValid(CachedTutorialManager))
+	AADTutorialGameState* GS = GetWorld()->GetGameState<AADTutorialGameState>();
+
+	if (GS && GS->GetCurrentPhase() == ETutorialPhase::Step4_Radar)
 	{
-		CachedTutorialManager->NotifyInteractionStart();
+		if (IsValid(CachedTutorialManager))
+		{
+			CachedTutorialManager->NotifyInteractionStart();
+		}
 	}
 }
 
@@ -191,13 +199,17 @@ void AADTutorialPlayerController::OnInventoryStarted(const FInputActionValue& Va
 	{
 		CachedTutorialManager->OnInventoryInputPressed();
 
-		if (CachedTutorialManager->IsGaugeObjectiveActive())
+		AADTutorialGameState* GS = GetWorld()->GetGameState<AADTutorialGameState>();
+
+		if (GS && GS->GetCurrentPhase() == ETutorialPhase::Step6_Inventory)
 		{
-			CachedTutorialManager->NotifyInteractionStart();
+			if (CachedTutorialManager->IsGaugeObjectiveActive())
+			{
+				CachedTutorialManager->NotifyInteractionStart();
+			}
 		}
 	}
 }
-
 
 void AADTutorialPlayerController::OnInventoryCompleted(const FInputActionValue& Value)
 {
@@ -210,9 +222,14 @@ void AADTutorialPlayerController::OnInventoryCompleted(const FInputActionValue& 
 
 void AADTutorialPlayerController::OnLightToggleStarted(const FInputActionValue& Value)
 {
-	if (IsValid(CachedTutorialManager))
+	AADTutorialGameState* GS = GetWorld()->GetGameState<AADTutorialGameState>();
+
+	if (GS && GS->GetCurrentPhase() == ETutorialPhase::Step8_LightToggle)
 	{
-		CachedTutorialManager->NotifyInteractionStart();
+		if (IsValid(CachedTutorialManager))
+		{
+			CachedTutorialManager->NotifyInteractionStart();
+		}
 	}
 }
 
@@ -226,42 +243,22 @@ void AADTutorialPlayerController::OnLightToggleCompleted(const FInputActionValue
 
 void AADTutorialPlayerController::OnBatteryStarted(const FInputActionValue& Value)
 {
-	if (IsValid(CachedTutorialManager))
-	{
-		CachedTutorialManager->NotifyInteractionStart();
-	}
 }
 
 void AADTutorialPlayerController::OnBatteryCompleted(const FInputActionValue& Value)
 {
-	if (IsValid(CachedTutorialManager))
-	{
-		CachedTutorialManager->NotifyInteractionEnd();
-	}
 }
 
 void AADTutorialPlayerController::OnDropStarted(const FInputActionValue& Value)
 {
-	if (IsValid(CachedTutorialManager))
-	{
-		CachedTutorialManager->NotifyInteractionStart();
-	}
 }
 
 void AADTutorialPlayerController::OnDropCompleted(const FInputActionValue& Value)
 {
-	if (IsValid(CachedTutorialManager))
-	{
-		CachedTutorialManager->NotifyInteractionEnd();
-	}
 }
 
 void AADTutorialPlayerController::OnReviveStarted(const FInputActionValue& Value)
 {
-	if (IsValid(CachedTutorialManager))
-	{
-		CachedTutorialManager->NotifyInteractionStart();
-	}
 }
 
 void AADTutorialPlayerController::OnReviveCompleted(const FInputActionValue& Value)
@@ -272,17 +269,17 @@ void AADTutorialPlayerController::OnReviveCompleted(const FInputActionValue& Val
 	}
 }
 
-void AADTutorialPlayerController::OnUseItem1(const FInputActionValue& Value)
-{
-	ReportItemAction(EPlayerActionTrigger::UseItem1);
+void AADTutorialPlayerController::OnUseItem1(const FInputActionValue& Value) 
+{ 
+	ReportItemAction(EPlayerActionTrigger::UseItem1); 
 }
 
-void AADTutorialPlayerController::OnUseItem2(const FInputActionValue& Value)
-{
-	ReportItemAction(EPlayerActionTrigger::UseItem2);
+void AADTutorialPlayerController::OnUseItem2(const FInputActionValue& Value) 
+{ 
+	ReportItemAction(EPlayerActionTrigger::UseItem2); 
 }
 
-void AADTutorialPlayerController::OnUseItem3(const FInputActionValue& Value)
-{
-	ReportItemAction(EPlayerActionTrigger::UseItem3);
+void AADTutorialPlayerController::OnUseItem3(const FInputActionValue& Value) 
+{ 
+	ReportItemAction(EPlayerActionTrigger::UseItem3); 
 }

--- a/Source/AbyssDiverUnderWorld/Framework/ADTutorialPlayerController.h
+++ b/Source/AbyssDiverUnderWorld/Framework/ADTutorialPlayerController.h
@@ -12,19 +12,17 @@ class ABYSSDIVERUNDERWORLD_API AADTutorialPlayerController : public AADPlayerCon
 {
 	GENERATED_BODY()
 
-public:
+	public:
 	AADTutorialPlayerController();
 
+public:
 	virtual void BeginPlay() override;
+	virtual void SetPawn(APawn* InPawn) override;
 
 	void RequestAdvanceTutorialPhase();
-
 	void ReportItemAction(EPlayerActionTrigger ItemActionType);
 
 protected:
-
-	virtual void SetPawn(APawn* InPawn) override;
-
 	void OnInteractStarted(const FInputActionValue& Value);
 	void OnInteractCompleted(const FInputActionValue& Value);
 
@@ -56,9 +54,6 @@ protected:
 	void CheckTutorialObjective(const FInputActionValue& Value, UInputAction* SourceAction);
 
 private:
-	UPROPERTY()
-	TObjectPtr<ATutorialManager> CachedTutorialManager;
-
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<UInputAction> ReviveAction;
 
@@ -68,12 +63,15 @@ private:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<UInputAction> DropAction;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Input", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<UInputAction> UseItem1Action;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Input", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<UInputAction> UseItem2Action;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Input", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<UInputAction> UseItem3Action;
+
+	UPROPERTY()
+	TObjectPtr<ATutorialManager> CachedTutorialManager;
 };

--- a/Source/AbyssDiverUnderWorld/Inventory/ADInventoryComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Inventory/ADInventoryComponent.cpp
@@ -23,6 +23,7 @@
 #include "NiagaraSystem.h"
 #include "Subsystems/SoundSubsystem.h"
 #include "Framework/ADGameInstance.h"
+#include "Framework/ADTutorialGameMode.h"
 #include "GameFramework/Pawn.h"
 #include "GameFramework/CharacterMovementComponent.h"
 #include "Interactable/EquipableComponent/EquipRenderComponent.h"
@@ -569,6 +570,10 @@ void UADInventoryComponent::RemoveBySlotIndex(uint8 SlotIndex, EItemType ItemTyp
 		if (bIsDropAction)
 		{
 			DropItem(Item);
+			if (AADTutorialGameMode* GM = GetWorld()->GetAuthGameMode<AADTutorialGameMode>())
+			{
+				GM->OnPlayerItemAction(EPlayerActionTrigger::Drop);
+			}
 		}
 		InventoryList.UpdateQuantity(InventoryIndex, INDEX_NONE);
 

--- a/Source/AbyssDiverUnderWorld/Tutorial/TutorialManager.cpp
+++ b/Source/AbyssDiverUnderWorld/Tutorial/TutorialManager.cpp
@@ -37,7 +37,7 @@ void ATutorialManager::BeginPlay()
 		SubtitleWidget = CreateWidget<UTutorialSubtitle>(GetWorld(), TutorialSubtitleClass);
 		if (SubtitleWidget)
 		{
-			SubtitleWidget->AddToViewport(20);
+			SubtitleWidget->AddToViewport(-100);
 			SubtitleWidget->SetVisibility(ESlateVisibility::Hidden);
 		}
 	}
@@ -56,7 +56,7 @@ void ATutorialManager::BeginPlay()
 		TutorialHintPanel = CreateWidget<UTutorialHintPanel>(GetWorld(), TutorialHintPanelClass);
 		if (TutorialHintPanel)
 		{
-			TutorialHintPanel->AddToViewport(10);
+			TutorialHintPanel->AddToViewport(-50);
 			TutorialHintPanel->SetVisibility(ESlateVisibility::Hidden);
 		}
 	}
@@ -66,7 +66,7 @@ void ATutorialManager::BeginPlay()
 		GaugeWidget = CreateWidget<UUserWidget>(GetWorld(), GaugeWidgetClass);
 		if (GaugeWidget)
 		{
-			GaugeWidget->AddToViewport(15);
+			GaugeWidget->AddToViewport(-10);
 			GaugeWidget->SetVisibility(ESlateVisibility::Collapsed);
 			GaugeProgressBar = Cast<UProgressBar>(GaugeWidget->GetWidgetFromName(TEXT("GaugeBar")));
 		}
@@ -77,7 +77,7 @@ void ATutorialManager::BeginPlay()
 		HighlightingWidget = CreateWidget<UTutorialHighlighting>(GetWorld(), HighlightingWidgetClass);
 		if (HighlightingWidget)
 		{
-			HighlightingWidget->AddToViewport(5); 
+			HighlightingWidget->AddToViewport(-5); 
 			HighlightingWidget->HighlightEnd(); 
 		}
 	}


### PR DESCRIPTION
---

## 📝 작업 상세 내용

**튜토리얼 게이지 관련 입력 오류 수정**
- Drop 단계 등 게이지를 채워야 하는 튜토리얼에서, 해당 단계와 관련 없는 키(스프린트, 레이더 등)를 눌러도 게이지가 차는 문제 발견
- ADTutorialPlayerController의 모든 입력 처리 함수에 현재 튜토리얼 단계를 확인하는 로직을 추가

**인벤토리 드래그 앤 드롭 비활성화 문제 해결**
- 튜토리얼 진행 시 다른 UI 위젯(자막 등)에 가려져 인벤토리 내에서 드래그 앤 드롭이 동작 안함
- 위젯 생성 시 Z-Order 값 수정해서 고침
- 드래그 앤 드롭 해서 아이템 2개 버리면 다음 단계로 넘어가게 수정(ADInventoryComponent에서 RemovebyIndex 부분 수정)

**인벤토리 아이템 추가**
- BP_TutorialGameMode에서 아이템 추가하는 로직 추가

---

## 📸 스크린샷 (선택)

---

## 🙋 리뷰어에게 요청사항
<!-- 리뷰 시 중점적으로 봐줬으면 하는 부분 -->
- 네이밍이 적절한지 확인 부탁드립니다
- 입력 처리 방식이 괜찮은지 봐주세요
---
