### PR TITLE
🩹 fix 5.6으로 migration 대비 코드 수정

### DIFF
--- a/Content/_AbyssDiver/Blueprints/UI/HUD/WBP_NameWidget.uasset
+++ b/Content/_AbyssDiver/Blueprints/UI/HUD/WBP_NameWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68f2f6dbfd857c7a382b8835bb47076b886c987e4c9aaef58d28ea9de5330666
-size 26159
+oid sha256:a4815d859dcc26c95ba68a415cc5510d7a903a50f9bc2fb8edebba773c28f7d3
+size 26380

--- a/Plugins/FlyingNa2e507475c2a7V10/Source/FlyingNavSystem/Private/OctreeRenderingComponent.h
+++ b/Plugins/FlyingNa2e507475c2a7V10/Source/FlyingNavSystem/Private/OctreeRenderingComponent.h
@@ -8,6 +8,7 @@
 #include "FlyingNavSystemTypes.h"
 #include "StaticMeshResources.h"
 #include "Math/GenericOctree.h"
+#include "DynamicMeshBuilder.h"
 
 #include "OctreeRenderingComponent.generated.h"
 

--- a/Source/AbyssDiverUnderWorld/Character/PlayerComponent/NameWidgetComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Character/PlayerComponent/NameWidgetComponent.cpp
@@ -4,7 +4,7 @@
 #include "NameWidgetComponent.h"
 
 #include "Kismet/GameplayStatics.h"
-#include "UI/NameWidget.h"
+#include "UI/ADNameWidget.h"
 
 UNameWidgetComponent::UNameWidgetComponent()
 {
@@ -31,7 +31,7 @@ void UNameWidgetComponent::BeginPlay()
 	LocalPlayerController = UGameplayStatics::GetPlayerController(GetWorld(), 0);
 	if (UUserWidget* UserWidget = GetUserWidgetObject())
 	{
-		if (UNameWidget* NameWidget = Cast<UNameWidget>(UserWidget))
+		if (UADNameWidget* NameWidget = Cast<UADNameWidget>(UserWidget))
 		{
 			NameWidget->SetNameText(NameText);
 		}
@@ -149,7 +149,7 @@ void UNameWidgetComponent::SetNameText(const FString& NewName)
 
 	if (UUserWidget* UserWidget = GetUserWidgetObject())
 	{
-		if (UNameWidget* NameWidget = Cast<UNameWidget>(UserWidget))
+		if (UADNameWidget* NameWidget = Cast<UADNameWidget>(UserWidget))
 		{
 			NameWidget->SetNameText(NameText);
 		}

--- a/Source/AbyssDiverUnderWorld/Inventory/ADInventoryComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Inventory/ADInventoryComponent.cpp
@@ -12,7 +12,7 @@
 #include "Framework/ADPlayerState.h"
 #include "Interactable/Item/ADUseItem.h"
 #include "Interactable/Item/UseFunction/UseStrategy.h"
-#include "Actions/PawnActionsComponent.h"
+//#include "Actions/PawnActionsComponent.h"
 #include "GameFramework/Character.h"
 #include "Interactable/Item/Component/EquipUseComponent.h"
 #include "UI/ChargeBatteryWidget.h"

--- a/Source/AbyssDiverUnderWorld/UI/ADNameWidget.cpp
+++ b/Source/AbyssDiverUnderWorld/UI/ADNameWidget.cpp
@@ -1,11 +1,11 @@
 ﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 
-#include "NameWidget.h"
+#include "ADNameWidget.h"
 
 #include "Components/RichTextBlock.h"
 
-void UNameWidget::SetNameText(const FString& NewName)
+void UADNameWidget::SetNameText(const FString& NewName)
 {
 	NameTextBlock->SetText(FText::FromString(NewName));
 }

--- a/Source/AbyssDiverUnderWorld/UI/ADNameWidget.h
+++ b/Source/AbyssDiverUnderWorld/UI/ADNameWidget.h
@@ -4,13 +4,13 @@
 
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
-#include "NameWidget.generated.h"
+#include "ADNameWidget.generated.h"
 
 /**
  * 
  */
 UCLASS()
-class ABYSSDIVERUNDERWORLD_API UNameWidget : public UUserWidget
+class ABYSSDIVERUNDERWORLD_API UADNameWidget : public UUserWidget
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION


---

## 📝 작업 상세 내용
- OctreeRenderingComponent : 헤더파일에 추가 인클루드
- NameWidget -> ADNameWidget : 5.6에는 NameWidget이라는 클래스가 엔진 코드에 존재, 이름 겹침 해결
- NameWidgetComponent, WBP_NameWidget : ADNameWidget으로 변화함에 따른 수정
- ADInventoryComponent : 5.6에서는 #include "Actions/PawnActionsComponent.h" 인클루드 하면 컴파일 오류남. 필요 없음
---
