### PR TITLE
✨ update Blowfish, GobleFish BT 수정 및 기타, ♻️ refactor Boss, Blowfish, GobleFish, Monster

### DIFF
--- a/Content/_AbyssDiver/Animations/Monster/GolbleFish/AM_GobleFish_MeleeAttack_1.uasset
+++ b/Content/_AbyssDiver/Animations/Monster/GolbleFish/AM_GobleFish_MeleeAttack_1.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5471cf7d8769a570e66b42cc3be799b66ee01e96f9c010ef0609135567efb32
-size 13491
+oid sha256:45ee7d448d2ae349be7d2b079f911ef2a86eaeeaf793c094b70dea7b30cecd4b
+size 13651

--- a/Content/_AbyssDiver/Animations/Monster/GolbleFish/AM_GobleFish_MeleeAttack_2.uasset
+++ b/Content/_AbyssDiver/Animations/Monster/GolbleFish/AM_GobleFish_MeleeAttack_2.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ecb1a587c8d8d9ffae5b6dcceab6ed40a44d1a4199c2ef47a08bb45c1359345
-size 13749
+oid sha256:09a81d94046d336bed0136e744621750ac060bb9816ae78885796fbf772b19ef
+size 13767

--- a/Content/_AbyssDiver/Blueprints/Boss/Blowfish/AIC_EnhancedBlowfish.uasset
+++ b/Content/_AbyssDiver/Blueprints/Boss/Blowfish/AIC_EnhancedBlowfish.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa34fc50b0bc6025bc8b6133357a838cb005aba9eaa016229a4bd4768f689dc6
-size 22938
+oid sha256:ba2d1bc47cf385b5d6a923ad86993b5867cdaefb213aa2771bac31e5d184fdbe
+size 22077

--- a/Content/_AbyssDiver/Blueprints/Boss/Blowfish/AIC_EnhancedBlowfish_Lagacy.uasset
+++ b/Content/_AbyssDiver/Blueprints/Boss/Blowfish/AIC_EnhancedBlowfish_Lagacy.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51fb01db564a3ca27121fa52bea17d747c4e346d51bc9bf471daff1551526c98
+size 22354

--- a/Content/_AbyssDiver/Blueprints/Boss/Blowfish/BB_Blowfish.uasset
+++ b/Content/_AbyssDiver/Blueprints/Boss/Blowfish/BB_Blowfish.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea9ef09019834a247f3b267e9f71b8b56cd5341ea72bb885f4fd971bb49fc3a5
+size 2899

--- a/Content/_AbyssDiver/Blueprints/Boss/Blowfish/BT_Blowfish.uasset
+++ b/Content/_AbyssDiver/Blueprints/Boss/Blowfish/BT_Blowfish.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f11a118f411db711c84a76530d278447c7685c0a61fad703508cfc9386f52176
-size 37983
+oid sha256:afe95943f48e53d6fc141cd0b88e7936b39122c94f270d9e9fdb30da23fb35d4
+size 65297

--- a/Content/_AbyssDiver/Blueprints/Boss/Blowfish/BT_Blowfish_Lagacy.uasset
+++ b/Content/_AbyssDiver/Blueprints/Boss/Blowfish/BT_Blowfish_Lagacy.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:482ac44f271681bbb504a6c25f04c294079073098c7e9f89aa04c2704412afc0
+size 37760

--- a/Content/_AbyssDiver/Blueprints/Monster/GobleFish/BP_GobleFish.uasset
+++ b/Content/_AbyssDiver/Blueprints/Monster/GobleFish/BP_GobleFish.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cc232954d6d94bb5a3aa3ccb34e023a549b2957e7659211389da4e5c9d6e7ad
-size 57225
+oid sha256:d3bd7177c6a92f2f85dc2b9c31044d98aaf4f4b90b8a82132778c74a57a18ae0
+size 57658

--- a/Content/_AbyssDiver/Blueprints/Monster/GobleFish/BT_GobleFish.uasset
+++ b/Content/_AbyssDiver/Blueprints/Monster/GobleFish/BT_GobleFish.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0fa548a68cc28efefca9268c8b7a4b5279fa04d7ce6e9f129c7a590459bc3d3c
-size 62596
+oid sha256:049fd1c13e2bb45fb3fe90c1c9e4d6be9da8d881b51ebe59e5d6a6e4d01fbf4d
+size 65406

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test2.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test2.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c53cad502b22468d8ca2fba26856418553a46c263dbf8f361e676246889fd92
-size 297416
+oid sha256:23cec87ff5d391514bfe88b02e0d66417b112442aff9fd188924db11e189b6e2
+size 296387

--- a/Source/AbyssDiverUnderWorld/Monster/AnimNotify/AnimNotify_MonsterDefaultAttack.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/AnimNotify/AnimNotify_MonsterDefaultAttack.cpp
@@ -33,7 +33,7 @@ void UAnimNotify_MonsterDefaultAttack::Notify(USkeletalMeshComponent* MeshComp, 
 	// 태그로 콜리전 가져오기
 	else
 	{
-		UCapsuleComponent* AttackCollision = Monster->FindComponentByTag<UCapsuleComponent>(CollisionTag);
+		UShapeComponent* AttackCollision = Monster->FindComponentByTag<UShapeComponent>(CollisionTag);
 		if (!IsValid(AttackCollision)) return;
 
 		// 오버랩 판정 시작

--- a/Source/AbyssDiverUnderWorld/Monster/BT/Commons/BTTask_SimpleChasePlayer.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/BT/Commons/BTTask_SimpleChasePlayer.cpp
@@ -3,6 +3,7 @@
 #include "AbyssDiverUnderWorld.h"
 
 #include "Monster/Monster.h"
+#include "Character/UnderwaterCharacter.h"
 
 #include "BehaviorTree/BehaviorTreeComponent.h"
 #include "BehaviorTree/BlackboardComponent.h"
@@ -28,10 +29,27 @@ void UBTTask_SimpleChasePlayer::TickTask(UBehaviorTreeComponent& OwnerComp, uint
 {
 	Super::TickTask(OwnerComp, NodeMemory, DeltaSeconds);
 
-	AMonster* Monster = Cast<AMonster>(OwnerComp.GetAIOwner()->GetPawn());
+	AAIController* AIController = OwnerComp.GetAIOwner();
+	AMonster* Monster = Cast<AMonster>(AIController->GetPawn());
 	if (Monster == nullptr)
 	{
 		LOGV(Error, TEXT("UBTTask_SimpleChasePlayer::TickTask : Monster is nullptr"));
+		FinishLatentTask(OwnerComp, EBTNodeResult::Failed);
+		return;
+	}
+
+	AUnderwaterCharacter* Player = Cast<AUnderwaterCharacter>(AIController->GetBlackboardComponent()->GetValueAsObject("TargetPlayer"));
+	if (Player == nullptr)
+	{
+		LOGV(Error, TEXT("Player IS Not Valid"));
+		FinishLatentTask(OwnerComp, EBTNodeResult::Failed);
+		return;
+	}
+
+	if (Player->IsHideInSeaweed())
+	{
+		//AIController->GetBlackboardComponent()->SetValueAsBool("bIsPlayerHidden", true);
+		Monster->RemoveDetection(Player);
 		FinishLatentTask(OwnerComp, EBTNodeResult::Failed);
 		return;
 	}

--- a/Source/AbyssDiverUnderWorld/Monster/Boss/Blowfish/Blowfish.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/Boss/Blowfish/Blowfish.cpp
@@ -115,10 +115,17 @@ void ABlowfish::Explosion()
 		}
 	}
 	
+	if (HasAuthority() == false)
+	{
+		return;
+	}
+
+	
 	// 복어 위치를 기준으로 ExplosionRadius 범위내에 있는 액터에게 ExplosionDamage를 가함
 	// ECC_WorldStatic으로 프리셋이 설정된 액터에 가려진 경우 데미지를 받지 않음
 	UGameplayStatics::ApplyRadialDamage(GetWorld(), ExplosionDamage, GetActorLocation(), ExplosionRadius,
 		UDamageType::StaticClass(), TArray<AActor*>(), this, GetController(), false, ECollisionChannel::ECC_WorldStatic);
 	
-	Destroy(true);
+	//Destroy(true);
+	OnDeath();
 }

--- a/Source/AbyssDiverUnderWorld/Monster/Boss/Boss.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/Boss/Boss.cpp
@@ -274,20 +274,25 @@ void ABoss::RotationToTarget(const FVector& InTargetLocation)
 	SetActorRotation(NewRotation);
 }
 
-void ABoss::Attack()
-{
-	const uint8 AttackType = FMath::RandRange(0, AttackAnimations.Num() - 1);
-	
-	if (IsValid(AttackAnimations[AttackType]))
-	{
-		ChaseAccumulatedTime = 0.f;
-		AnimInstance->OnMontageEnded.RemoveDynamic(this, &ABoss::OnAttackMontageEnded);
-		AnimInstance->OnMontageEnded.AddDynamic(this, &ABoss::OnAttackMontageEnded);
-		M_PlayMontage(AttackAnimations[AttackType]);
-	}
-
-	bIsAttacking = true;
-}
+//void ABoss::Attack()
+//{
+//	const uint8 AttackType = FMath::RandRange(0, AttackAnimations.Num() - 1);
+//	
+//	if (!AnimInstance) return;
+//
+//	// If any montage is playing, prevent duplicate playback
+//	if (AnimInstance->IsAnyMontagePlaying()) return;
+//
+//	if (IsValid(AttackAnimations[AttackType]))
+//	{
+//		ChaseAccumulatedTime = 0.f;
+//		AnimInstance->OnMontageEnded.RemoveDynamic(this, &ABoss::OnAttackMontageEnded);
+//		AnimInstance->OnMontageEnded.AddDynamic(this, &ABoss::OnAttackMontageEnded);
+//		M_PlayMontage(AttackAnimations[AttackType]);
+//	}
+//
+//	bIsAttacking = true;
+//}
 
 void ABoss::OnAttackEnded()
 {

--- a/Source/AbyssDiverUnderWorld/Monster/Boss/Boss.h
+++ b/Source/AbyssDiverUnderWorld/Monster/Boss/Boss.h
@@ -138,7 +138,7 @@ public:
 	virtual void RotationToTarget(const FVector& InTargetLocation);
 
 	/** 보스의 공격 시 애니메이션 재생*/
-	virtual void Attack() override;
+	//virtual void Attack() override;
 	virtual void OnAttackEnded() override;
 
 	/** 보스의 공격이 끝난 후 타격 판정을 초기화하는 함수

--- a/Source/AbyssDiverUnderWorld/Monster/GobleFish/GobleFish.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/GobleFish/GobleFish.cpp
@@ -13,6 +13,17 @@ AGobleFish::AGobleFish()
 	GobleFishHitSphere->InitSphereRadius(20.0f);
 	GobleFishHitSphere->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 	GobleFishHitSphere->SetHiddenInGame(true);
+
+	GobleFishHitSphere->ComponentTags.Add(TEXT("GobleFishHitSphere"));
+}
+
+void AGobleFish::BeginPlay()
+{
+	Super::BeginPlay();
+	GetMesh()->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+	GetMesh()->OnComponentBeginOverlap.AddDynamic(this, &AGobleFish::OnMeshOverlapBegin);
+	GobleFishHitSphere->OnComponentBeginOverlap.AddDynamic(this, &AGobleFish::OnMeshOverlapBegin);
 }
 
 void AGobleFish::FireProjectile()
@@ -78,6 +89,8 @@ void AGobleFish::Attack()
 				M_PlayMontage(AttackAnimations[AttackType]);
 			}
 		}
+
+		bIsAttacking = true;
 	}
 	else if (BlackboardComponent->GetValueAsBool("bInRangedRange"))
 	{
@@ -92,5 +105,13 @@ void AGobleFish::Attack()
 		}
 	}
 	else return;
+}
+
+void AGobleFish::OnDeath()
+{
+	GetMesh()->OnComponentBeginOverlap.RemoveAll(this);
+	GobleFishHitSphere->OnComponentBeginOverlap.RemoveAll(this);
+
+	Super::OnDeath();
 }
 

--- a/Source/AbyssDiverUnderWorld/Monster/GobleFish/GobleFish.h
+++ b/Source/AbyssDiverUnderWorld/Monster/GobleFish/GobleFish.h
@@ -17,12 +17,21 @@ class ABYSSDIVERUNDERWORLD_API AGobleFish : public AMonster
 public:
 	AGobleFish();
 
+protected:
+
+	virtual void BeginPlay() override;
+
 #pragma region Method
 public:
 	UFUNCTION(BlueprintCallable)
 	void FireProjectile();
 
 	virtual void Attack() override;
+
+protected:
+
+	virtual void OnDeath() override;
+
 #pragma endregion
 
 #pragma region Variable


### PR DESCRIPTION

---

# 📝 작업 상세 내용
## ✨ update
### BT 수정
- AIC_EnhancedBlowfish : 부모를 MonsterAIController로 변경
- BB_Blowfish, BT_Blowfish, BP_GobleFish, BT_GobleFish : MonsterState기반 재설계

### AnimNotify_MonsterDefaultAttack
- UCapsuleComponent -> UShapeComponent (범용성)

### BTTask_SimpleChasePlayer
- 해초사이에 숨을 때 로직 추가

## ♻️ refactor
### Boss
- Attack함수 Monster 것으로 사용

### Blowfish
- 폭발로 사망시 OnDeath 호출
- 폭발 데미지는 서버에서만 처리

### GobleFish
- 공격 로직 Blowfish와 동일하게 콜리전 기반으로 변경
- Beginplay - Overlap 콜백 바인딩
- 생성자 : AM에 쓰일 태그 추가
- AnimNotify_MonsterDefaultAttack : 특정 타이밍에 공격 콜리전 활성화
- AM_GobleFish_MeleeAttack_1, AM_GobleFish_MeleeAttack_2 : AnimNotify_MonsterDefaultAttack 추가

### Monster
- NotifyLightExposure : 플레이어가 숨은 상태이면 감지하지 않음
- Attack : 이미 어택 몽타주가 플레이 중이면 실행하지 않음
- ApplyPhysicsSimulation : 필요 없는 로직 주석

---
