### PR TITLE
✨ update tick 최적화 및 기타

### DIFF
--- a/Content/_AbyssDiver/Blueprints/Monster/HorrorCreature/BP_HorrorCreature.uasset
+++ b/Content/_AbyssDiver/Blueprints/Monster/HorrorCreature/BP_HorrorCreature.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8538dbb6c4a1b87487312ddc171682e1ae762907b8a82b6088bfaed59b545d89
-size 60668
+oid sha256:4188437efe703a33dba8337f1912cc332b6647a8c3d5104a43aa66c4627804dd
+size 60609

--- a/Content/_AbyssDiver/Blueprints/Projectile/BP_ADShotgunBullet.uasset
+++ b/Content/_AbyssDiver/Blueprints/Projectile/BP_ADShotgunBullet.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce23de56dd0e0fad46442e132fe0ce4be4401fabd72086c05a09fa9cff0c2f78
-size 30957
+oid sha256:05bb2121e5b63e1736da9d5d5e71ec407243e2f328424933f8cd2375accd5158
+size 51655

--- a/Source/AbyssDiverUnderWorld/Monster/Components/AquaticMovementComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/Components/AquaticMovementComponent.cpp
@@ -112,6 +112,8 @@ void UAquaticMovementComponent::TickComponent(float DeltaTime, ELevelTick TickTy
 // === 이동 업데이트 ===
 void UAquaticMovementComponent::UpdateMovement(float DeltaTime)
 {
+    FString ForDebug = FString::Printf(TEXT("UAquaticMovementComponent::UpdateMovement(%s)"), *OwnerCharacter->GetName());
+    TRACE_CPUPROFILER_EVENT_SCOPE_STR_CONDITIONAL(*ForDebug, true);
     // 목표 도달 확인
     if (bHasTarget)
     {
@@ -233,7 +235,7 @@ void UAquaticMovementComponent::UpdateMovement(float DeltaTime)
         {
             FHitResult PredictHit;
             FVector CurrentLocation = OwnerCharacter->GetActorLocation();
-            
+            TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(TEXT("UpdateMovement_CollisionChecks"));
             // 이동 방향으로 미리 체크
             if (GetWorld()->LineTraceSingleByChannel(PredictHit, CurrentLocation, NewLocation + CurrentVelocity.GetSafeNormal() * 50.0f, ECC_WorldStatic))
             {
@@ -260,6 +262,8 @@ void UAquaticMovementComponent::UpdateMovement(float DeltaTime)
 
 FVector UAquaticMovementComponent::CalculateSteeringForce() const
 {
+    FString ForDebug = FString::Printf(TEXT("UAquaticMovementComponent::CalculateSteeringForce(%s)"), *OwnerCharacter->GetName());
+    TRACE_CPUPROFILER_EVENT_SCOPE_STR_CONDITIONAL(*ForDebug, true);
     if (!bHasTarget) return FVector::ZeroVector;
 
     FVector ToTarget = TargetLocation - OwnerCharacter->GetActorLocation();
@@ -296,6 +300,8 @@ FVector UAquaticMovementComponent::CalculateSteeringForce() const
 
 FVector UAquaticMovementComponent::CalculateAvoidanceForce() 
 {
+    FString ForDebug = FString::Printf(TEXT("UAquaticMovementComponent::CalculateAvoidanceForce(%s)"), *OwnerCharacter->GetName());
+    TRACE_CPUPROFILER_EVENT_SCOPE_STR_CONDITIONAL(*ForDebug, true);
     FVector AvoidanceForce = FVector::ZeroVector;
     FVector CurrentLocation = OwnerCharacter->GetActorLocation();
     FVector Forward = OwnerCharacter->GetActorForwardVector();
@@ -481,6 +487,7 @@ FVector UAquaticMovementComponent::CalculateAvoidanceForce()
 // === 경로 관리 ===
 void UAquaticMovementComponent::UpdateTrajectory(float DeltaTime)
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("UAquaticMovementComponent::UpdateTrajectory"));
     // LOD 기반 기록 간격
     float RecordInterval = GetTrajectoryRecordInterval();
 
@@ -1070,6 +1077,7 @@ void UAquaticMovementComponent::GetPositionAndRotationAlongPath(float DistanceFr
 
 void UAquaticMovementComponent::UpdateBoneTrailsDistanceBased(float DeltaTime)
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("UAquaticMovementComponent::UpdateBoneTrailsDistanceBased"));
     if (!CharacterMesh) return;
 
     // 본 간 거리 계산이 안되어 있으면 계산
@@ -1238,6 +1246,7 @@ FTransform UAquaticMovementComponent::GetBoneTrailTransform(const FName& BoneNam
 // === 디버그 시각화 ===
 void UAquaticMovementComponent::DrawDebugVisualization()
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("UAquaticMovementComponent::DrawDebugVisualization"));
     if (!GetWorld()) return;
 
     // 경로 그리기

--- a/Source/AbyssDiverUnderWorld/Monster/Components/TickControlComponent.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/Components/TickControlComponent.cpp
@@ -311,6 +311,13 @@ void UTickControlComponent::UpdateTickRate()
     for (UActorComponent* Component : TargetComponents)
     {
         SetComponentTickRate(Component, TickInterval);
+        
+        // 임시로 TickInterval이 1000을 넘으면 틱 자체를 비활성화 하도록 설정
+        if (TickInterval > 1000.0f)
+        {
+            Component->SetComponentTickEnabled(false);
+        }
+
     }
 
 	// 모든 등록된 액터에 틱 레이트 적용

--- a/Source/AbyssDiverUnderWorld/Monster/EyeStalker/EyeStalker.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/EyeStalker/EyeStalker.cpp
@@ -1,8 +1,21 @@
 #include "Monster/EyeStalker/EyeStalker.h"
 
+#include "Monster/Components/AquaticMovementComponent.h"
+#include "Monster/Components/TickControlComponent.h"
+
 AEyeStalker::AEyeStalker()
 {
 	PrimaryActorTick.bCanEverTick = false;
+}
+
+void AEyeStalker::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (AquaticMovementComponent)
+	{
+		TickControlComponent->UnregisterComponent(AquaticMovementComponent);
+	}
 }
 
 void AEyeStalker::M_SetEyeOpenness_Implementation(float Openness)

--- a/Source/AbyssDiverUnderWorld/Monster/EyeStalker/EyeStalker.h
+++ b/Source/AbyssDiverUnderWorld/Monster/EyeStalker/EyeStalker.h
@@ -15,6 +15,10 @@ class ABYSSDIVERUNDERWORLD_API AEyeStalker : public AMonster
 public:
 	AEyeStalker();
 
+protected:
+
+	virtual void BeginPlay() override;
+
 public:
 	UFUNCTION(NetMulticast, Reliable)
 	void M_SetEyeOpenness(float Openness);

--- a/Source/AbyssDiverUnderWorld/Monster/Limadon/Limadon.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/Limadon/Limadon.cpp
@@ -1,8 +1,13 @@
 #include "Monster/Limadon/Limadon.h"
+
 #include "AbyssDiverUnderWorld.h"
-#include "Monster/Boss/Enum/EBossState.h"
+
+#include "Monster/Components/AquaticMovementComponent.h"
+#include "Monster/Components/TickControlComponent.h"
+
 #include "Character/StatComponent.h"
 #include "Character/UnderwaterCharacter.h"
+
 #include "Components/CapsuleComponent.h"
 
 ALimadon::ALimadon()
@@ -22,7 +27,7 @@ ALimadon::ALimadon()
 
 	RightSphereMesh = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("Right Sphere Mesh"));
 	RightSphereMesh->SetupAttachment(GetMesh());
-	
+
 	StopCaptureHealthCriteria = 1000.0f;
 
 	bReplicates = true;
@@ -36,6 +41,14 @@ void ALimadon::BeginPlay()
 
 	SetMonsterState(EMonsterState::Investigate);
 	BiteAttackCollision->OnComponentBeginOverlap.AddDynamic(this, &ALimadon::OnBiteCollisionOverlapBegin);
+
+	TickControlComponent->RegisterComponent(LeftSphereMesh);
+	TickControlComponent->RegisterComponent(RightSphereMesh);
+
+	if (AquaticMovementComponent)
+	{
+		TickControlComponent->UnregisterComponent(AquaticMovementComponent);
+	}
 }
 
 void ALimadon::BiteVariableInitialize()

--- a/Source/AbyssDiverUnderWorld/Monster/Monster.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/Monster.cpp
@@ -1,24 +1,25 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿#include "Monster/Monster.h"
 
-
-#include "Monster/Monster.h"
-#include "Components/SplineComponent.h"
-#include "Character/StatComponent.h"
-#include "BehaviorTree/BlackboardComponent.h"
-#include "Net/UnrealNetwork.h"
-#include "GameFramework/CharacterMovementComponent.h"
 #include "AbyssDiverUnderWorld.h"
-#include "NiagaraFunctionLibrary.h"
-#include "Character/UnderwaterCharacter.h"
-#include "Components/CapsuleComponent.h"
-#include "Monster/Effect/CameraControllerComponent.h"
-#include "Container/BlackboardKeys.h"
-#include "Kismet/GameplayStatics.h"
-#include "Interactable/OtherActors/Radars/RadarReturn2DComponent.h"
 
 #include "Monster/Components/AquaticMovementComponent.h"
 #include "Monster/Components/TickControlComponent.h"
 #include "Monster/EPerceptionType.h"
+#include "Monster/Effect/CameraControllerComponent.h"
+
+#include "Character/UnderwaterCharacter.h"
+#include "Character/StatComponent.h"
+
+#include "Container/BlackboardKeys.h"
+#include "Interactable/OtherActors/Radars/RadarReturn2DComponent.h"
+
+#include "Components/CapsuleComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "NiagaraFunctionLibrary.h"
+#include "GameFramework/CharacterMovementComponent.h"
+#include "Net/UnrealNetwork.h"
+#include "BehaviorTree/BlackboardComponent.h"
+#include "Components/SplineComponent.h"
 
 AMonster::AMonster()
 {
@@ -61,9 +62,14 @@ AMonster::AMonster()
 
 	// 새로운 물리 기반 수중 이동 컴포넌트 초기화
 	AquaticMovementComponent = CreateDefaultSubobject<UAquaticMovementComponent>("Aquatic Movement Component");
+	// 기존 이동 컴포넌트는 사용하지 않음
+	GetCharacterMovement()->PrimaryComponentTick.bCanEverTick = false;
+	GetCharacterMovement()->SetActive(false);
+	GetCharacterMovement()->SetComponentTickEnabled(false);
 
 	// 틱 최적화용 컴포넌트 초기화
 	TickControlComponent = CreateDefaultSubobject<UTickControlComponent>(TEXT("Tick Control Component"));
+
 }
 
 void AMonster::BeginPlay()
@@ -76,6 +82,7 @@ void AMonster::BeginPlay()
 	if (AquaticMovementComponent)
 	{
 		AquaticMovementComponent->InitComponent(this);
+		TickControlComponent->RegisterComponent(AquaticMovementComponent);
 	}
 
 	CurrentMoveSpeed = StatComponent->MoveSpeed;

--- a/Source/AbyssDiverUnderWorld/Monster/Serpmare/Serpmare.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/Serpmare/Serpmare.cpp
@@ -1,5 +1,8 @@
 ﻿#include "Monster/Serpmare/Serpmare.h"
 
+#include "Monster/Components/AquaticMovementComponent.h"
+#include "Monster/Components/TickControlComponent.h"
+
 #include "Character/UnderwaterCharacter.h"
 
 ASerpmare::ASerpmare()
@@ -16,6 +19,14 @@ void ASerpmare::BeginPlay()
 	Super::BeginPlay();
 	GetMesh()->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
 	GetMesh()->OnComponentBeginOverlap.AddDynamic(this, &ASerpmare::OnMeshOverlapBegin);
+
+	TickControlComponent->RegisterComponent(LowerBodyMesh);
+	TickControlComponent->RegisterComponent(WeakPointMesh);
+
+	if (AquaticMovementComponent)
+	{
+		TickControlComponent->UnregisterComponent(AquaticMovementComponent);
+	}
 }
 
 void ASerpmare::Attack()

--- a/Source/AbyssDiverUnderWorld/Projectile/ADFlareGunBullet.cpp
+++ b/Source/AbyssDiverUnderWorld/Projectile/ADFlareGunBullet.cpp
@@ -7,6 +7,7 @@ AADFlareGunBullet::AADFlareGunBullet()
 {
 	FlareMesh = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("FlareMesh"));
 	FlareMesh->SetupAttachment(RootComponent);
+	FlareMesh->PrimaryComponentTick.bCanEverTick = false;
 
 	FlareLight = CreateDefaultSubobject<UPointLightComponent>(TEXT("FlareLight"));
 	FlareLight->SetupAttachment(RootComponent);
@@ -44,4 +45,22 @@ void AADFlareGunBullet::OnOverlapBegin(UPrimitiveComponent* OverlappedComp, AAct
 	//AttachToComponent(OtherComp, FAttachmentTransformRules::KeepWorldTransform, SweepResult.BoneName);
 
 	
+}
+
+void AADFlareGunBullet::Activate()
+{
+	Super::Activate();
+
+	FlareMesh->PrimaryComponentTick.bCanEverTick = true;
+	FlareMesh->SetComponentTickEnabled(true);
+	FlareMesh->PrimaryComponentTick.bStartWithTickEnabled = true;
+}
+
+void AADFlareGunBullet::Deactivate()
+{
+	Super::Deactivate();
+
+	FlareMesh->PrimaryComponentTick.bCanEverTick = false;
+	FlareMesh->SetComponentTickEnabled(false);
+	FlareMesh->PrimaryComponentTick.bStartWithTickEnabled = false;
 }

--- a/Source/AbyssDiverUnderWorld/Projectile/ADFlareGunBullet.h
+++ b/Source/AbyssDiverUnderWorld/Projectile/ADFlareGunBullet.h
@@ -12,16 +12,24 @@ class ABYSSDIVERUNDERWORLD_API AADFlareGunBullet : public AADProjectileBase
 	GENERATED_BODY()
 	
 public:
+
 	AADFlareGunBullet();
 
-#pragma region Method
 public:
 	virtual void BeginPlay() override;
+
+#pragma region Method
+
+public:
+
 	virtual void InitializeSpeed(const FVector& Dir, uint32 Speed) override;
 
 	virtual void OnOverlapBegin(UPrimitiveComponent* OverlappedComp, AActor* OtherActor,
 		UPrimitiveComponent* OtherComp, int32 OtherBodyIndex,
 		bool bFromSweep, const FHitResult& SweepResult) override;
+
+	virtual void Activate() override;
+	virtual void Deactivate() override;
 
 protected:
 	
@@ -37,7 +45,7 @@ protected:
 	UPROPERTY(EditAnywhere)
 	TObjectPtr<USphereComponent> FlareSphereCollision;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TObjectPtr<USkeletalMeshComponent> FlareMesh;
 	UPROPERTY(VisibleAnywhere)
 	TObjectPtr<UPointLightComponent> FlareLight;

--- a/Source/AbyssDiverUnderWorld/Projectile/ADProjectileBase.cpp
+++ b/Source/AbyssDiverUnderWorld/Projectile/ADProjectileBase.cpp
@@ -96,6 +96,8 @@ void AADProjectileBase::Activate()
     if (HasAuthority())
     {
         ProjectileMovementComp->SetActive(true);
+        ProjectileMovementComp->PrimaryComponentTick.bCanEverTick = true;
+        ProjectileMovementComp->SetComponentTickEnabled(true);
 
         float DeactivateDelay = 10.0f;
 	    GetWorld()->GetTimerManager().SetTimer(LifeTimerHandle, this, &AADProjectileBase::Deactivate, DeactivateDelay, false);
@@ -115,12 +117,17 @@ void AADProjectileBase::Deactivate()
         TrailEffect->Deactivate();
     }
 
-    if(ObjectPool)
+    if (ObjectPool)
+    {
         ObjectPool->ReturnObject();
+    }
+        
 	GetWorld()->GetTimerManager().ClearTimer(LifeTimerHandle);
     GetWorld()->GetTimerManager().ClearTimer(TrailDeactivateTimerHandle);
     SetOwner(nullptr);
     ProjectileMovementComp->SetActive(false);
+    ProjectileMovementComp->PrimaryComponentTick.bCanEverTick = false;
+    ProjectileMovementComp->SetComponentTickEnabled(false);
 }
 
 void AADProjectileBase::InitializeTransform(const FVector& Location, const FRotator& Rotation)

--- a/Source/AbyssDiverUnderWorld/Projectile/ADProjectileBase.h
+++ b/Source/AbyssDiverUnderWorld/Projectile/ADProjectileBase.h
@@ -32,8 +32,8 @@ public:
 	void M_EffectActivate(bool bActivate);
 	void M_EffectActivate_Implementation(bool bActivate);
 
-	void Activate() override;
-	void Deactivate() override;
+	virtual void Activate() override;
+	virtual void Deactivate() override;
 
 	void InitializeTransform(const FVector& Location, const FRotator& Rotation);
 	virtual void InitializeSpeed(const FVector& ShootDirection, const uint32 Speed);

--- a/Source/AbyssDiverUnderWorld/Projectile/ADSpearGunBullet.cpp
+++ b/Source/AbyssDiverUnderWorld/Projectile/ADSpearGunBullet.cpp
@@ -30,6 +30,7 @@ AADSpearGunBullet::AADSpearGunBullet() :
     StaticMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("SkeletalMesh"));
     StaticMesh->SetupAttachment(RootComponent);
     StaticMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision); 
+    StaticMesh->PrimaryComponentTick.bCanEverTick = false;
 
     Damage = 450.0f;
 
@@ -121,6 +122,15 @@ void AADSpearGunBullet::OnOverlapBegin(UPrimitiveComponent* OverlappedComp, AAct
 
 }
 
+void AADSpearGunBullet::Activate()
+{
+    Super::Activate();
+
+    // 틱 활성화
+    StaticMesh->PrimaryComponentTick.bCanEverTick = true;
+    StaticMesh->SetComponentTickEnabled(true);
+}
+
 void AADSpearGunBullet::Deactivate()
 {
     Super::Deactivate();
@@ -133,12 +143,17 @@ void AADSpearGunBullet::Deactivate()
     StaticMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
     StaticMesh->SetCollisionProfileName("NoCollision");
 
+
     // 부착 해제
     DetachFromActor(FDetachmentTransformRules::KeepWorldTransform);
     StaticMesh->AttachToComponent(RootComponent, FAttachmentTransformRules::KeepRelativeTransform);
     StaticMesh->SetRelativeLocation(FVector::ZeroVector);
     StaticMesh->SetRelativeRotation(InitialRotator);
     SetActorScale3D(FVector::OneVector);
+
+    // 틱 비활성화
+    StaticMesh->PrimaryComponentTick.bCanEverTick = false;
+    StaticMesh->SetComponentTickEnabled(false);
 }
 
 void AADSpearGunBullet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const

--- a/Source/AbyssDiverUnderWorld/Projectile/ADSpearGunBullet.h
+++ b/Source/AbyssDiverUnderWorld/Projectile/ADSpearGunBullet.h
@@ -28,6 +28,7 @@ class ABYSSDIVERUNDERWORLD_API AADSpearGunBullet : public AADProjectileBase
 
 #pragma region Method
 public:
+	virtual void Activate() override;
 	virtual void Deactivate() override;
 protected:
 	virtual void BeginPlay() override;

--- a/Source/AbyssDiverUnderWorld/Projectile/PoolableItem.cpp
+++ b/Source/AbyssDiverUnderWorld/Projectile/PoolableItem.cpp
@@ -21,6 +21,8 @@ void APoolableItem::Activate()
 	SetActorHiddenInGame(false);
 	SetActorEnableCollision(true);
 	SetActorTickEnabled(true);
+
+	OnPoolableItemActivate();
 }
 
 void APoolableItem::Deactivate()
@@ -32,6 +34,8 @@ void APoolableItem::Deactivate()
 	SetActorHiddenInGame(true);
 	SetActorEnableCollision(false);
 	SetActorTickEnabled(false);
+
+	OnPoolableItemDeactivated();
 }
 
 void APoolableItem::SetProjectileId(int8 Id)

--- a/Source/AbyssDiverUnderWorld/Projectile/PoolableItem.h
+++ b/Source/AbyssDiverUnderWorld/Projectile/PoolableItem.h
@@ -29,6 +29,14 @@ public:
 	bool GetIsActive() const { return bIsActive; }
 
 protected:
+
+	UFUNCTION(BlueprintImplementableEvent)
+	void OnPoolableItemActivate();
+
+	UFUNCTION(BlueprintImplementableEvent)
+	void OnPoolableItemDeactivated();
+
+protected:
 	UPROPERTY(Replicated)
 	int8 ProjectileId = -1;
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Pool")


### PR DESCRIPTION


---

## 📝 작업 상세 내용
### AquaticMovementComponent
- 언리얼 인사이트 세부 분석용 매크로 추가

### TickControlComponent
- 임시로 TickInterval이 1000이 넘을 경우 틱 자체를 꺼버리는 기능 추가

### 고정형 몬스터들
- AquaticMovementComponent를 사용하지 않으므로 최적화 필요 없음 -> TickControlComponent 등록 해제
- Limadon, Serpmare : 소유한 메쉬 틱 전부 최적화 하도록 TickControlComponent에 등록

### Monster
- 기존 CharacterMovementComponent는 사용하지 않으므로 틱 비활성화 -> 성능 먹고있었음

### PoolableItems
- PoolableItem : 블루프린트 상에서 구현 하는 OnPoolableItemActivate, OnPoolableItemDeactivated 추가
- ADFlareGunBullet : FlareMesh 틱 비활성화, Activate 될때만 다시 틱 활성화
- ADSpearGunBullet : StaticMesh 틱 비활성화, Activate 될 때만 다시 틱 활성화
- ADProjectileBase : ProjectileMovementComp Activate일 때만 활성화
- BP_ADShotgunBullet : Mesh가 블루프린트 상에 있기 때문에 블루프린트에서 Mesh 틱 비활성화, Activate일 때만 활성화

### 기타
- BP_HorrorCreature : 디버그 비활성화
---
