### PR TITLE
🐛 bugfix EyeStalker 눈꺼풀, 응시 방향 ✨ update EyeStalker 피격 모션, 몬스터 넉백 기능

### DIFF
--- a/Content/TentacleEyes/Blueprints/BP_TentacleEye.uasset
+++ b/Content/TentacleEyes/Blueprints/BP_TentacleEye.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:913fefc838c3f14ac36455eba10fd1e5bd6e80f48001365d6b9e31b152d4d999
-size 717056
+oid sha256:dbc400ac922b4624bc16ef44b6c57f105c236f281139f4e7bf91658738fb1f6f
+size 761056

--- a/Content/TentacleEyes/Meshes/Skeletal/SK_TentacleEye_Thick.uasset
+++ b/Content/TentacleEyes/Meshes/Skeletal/SK_TentacleEye_Thick.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e67e26376d95263b5656ea2d5985a5d71a970df69c7d852ae7ff36e9c9f2d07
-size 2018274
+oid sha256:b9f9459d757ded675a78423c09dde0a94ae7c4ce73528ec1436a23f2b9dc5ce8
+size 2215721

--- a/Content/TentacleEyes/Meshes/Skeletal/SK_TentacleEye_Thin.uasset
+++ b/Content/TentacleEyes/Meshes/Skeletal/SK_TentacleEye_Thin.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77fbbda6ca1bb328966a46512340c873c5fb0cea6383d3146dd9b6b2155153de
-size 2021420
+oid sha256:e8f019faf7a6868df4ac309870858924ed3aa8823e6ac374d0114808b28ecc48
+size 2217727

--- a/Content/_AbyssDiver/Blueprints/Monster/EyeStalker/BP_EyeStalker.uasset
+++ b/Content/_AbyssDiver/Blueprints/Monster/EyeStalker/BP_EyeStalker.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1509c90bbd2fc55a33d075b73d5567ac4025ca09e51f32f044e7efee7cb829fe
-size 166401
+oid sha256:70f07026f8ab3c8572089846089e2f120dfe7c4777adcbef9319fdaf2da2b5df
+size 177912

--- a/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test2.umap
+++ b/Content/_AbyssDiver/Maps/Prototypes_Test/HSRTest/HSR_Test2.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4bd0baff37bec327493ea6381843cd10261e01423f40e657f683e5a589c06fbe
-size 471191
+oid sha256:bb7d15370387883c9f80cd135c693a4477675eba8de31ffd975f2d938ba293e4
+size 341022

--- a/Source/AbyssDiverUnderWorld/Monster/EyeStalker/EyeStalker.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/EyeStalker/EyeStalker.cpp
@@ -26,6 +26,8 @@ float AEyeStalker::TakeDamage(float DamageAmount, FDamageEvent const& DamageEven
 {
 	float Damage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
 
+	OnEyeStalkerDamaged();
+
 	AMonsterAIController* AIC = Cast<AMonsterAIController>(GetController());
 	if (AIC == nullptr)
 	{
@@ -147,6 +149,11 @@ void AEyeStalker::RemoveDetection(AActor* Actor)
 			}
 		}
 	}
+}
+
+void AEyeStalker::ReceiveKnockback(const FVector& Force)
+{
+	// 넉백 당하지 않음.
 }
 
 void AEyeStalker::M_SetEyeOpenness_Implementation(float Openness)

--- a/Source/AbyssDiverUnderWorld/Monster/EyeStalker/EyeStalker.h
+++ b/Source/AbyssDiverUnderWorld/Monster/EyeStalker/EyeStalker.h
@@ -28,6 +28,7 @@ public:
 	virtual void NotifyLightExposure(float DeltaTime, float TotalExposedTime, const FVector& PlayerLocation, AActor* PlayerActor) override;
 	virtual void AddDetection(AActor* Actor);
 	virtual void RemoveDetection(AActor* Actor);
+	virtual void ReceiveKnockback(const FVector& Force) override;
 
 public:
 	UFUNCTION(NetMulticast, Reliable)
@@ -50,5 +51,10 @@ public:
 	
 	UFUNCTION(BlueprintImplementableEvent)
 	void SetDetectedState(bool bDetected);
+
+protected:
+
+	UFUNCTION(BlueprintImplementableEvent)
+	void OnEyeStalkerDamaged();
 	
 };

--- a/Source/AbyssDiverUnderWorld/Monster/Limadon/Limadon.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/Limadon/Limadon.cpp
@@ -124,6 +124,11 @@ void ALimadon::NotifyLightExposure(float DeltaTime, float TotalExposedTime, cons
 	// Limadon은 빛에 반응 하지 않음
 }
 
+void ALimadon::ReceiveKnockback(const FVector& Force)
+{
+	// 넉백 당하지 않음.
+}
+
 void ALimadon::Spit()
 {
 	if (!IsValid(GetTarget()))

--- a/Source/AbyssDiverUnderWorld/Monster/Limadon/Limadon.h
+++ b/Source/AbyssDiverUnderWorld/Monster/Limadon/Limadon.h
@@ -25,6 +25,8 @@ public:
 	
 	virtual void NotifyLightExposure(float DeltaTime, float TotalExposedTime, const FVector& PlayerLocation, AActor* PlayerActor) override;
 
+	virtual void ReceiveKnockback(const FVector& Force) override;
+
 	void BiteVariableInitialize();
 
 	UFUNCTION(BlueprintImplementableEvent)

--- a/Source/AbyssDiverUnderWorld/Monster/Monster.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/Monster.cpp
@@ -507,6 +507,14 @@ void AMonster::OnAttackEnded()
 	AttackedPlayers.Empty();
 }
 
+void AMonster::ReceiveKnockback(const FVector& Force)
+{
+	if (UCharacterMovementComponent* MovementComp = GetCharacterMovement())
+	{
+		MovementComp->AddImpulse(Force, true);
+	}
+}
+
 void AMonster::M_PlayMontage_Implementation(UAnimMontage* AnimMontage, float InPlayRate, FName StartSectionName)
 {
 	PlayAnimMontage(AnimMontage, InPlayRate, StartSectionName);

--- a/Source/AbyssDiverUnderWorld/Monster/Monster.h
+++ b/Source/AbyssDiverUnderWorld/Monster/Monster.h
@@ -44,6 +44,8 @@ public:
 
 	virtual void OnAttackEnded();
 
+	virtual void ReceiveKnockback(const FVector& Force);
+
 	UFUNCTION(NetMulticast, Reliable)
 	void M_PlayMontage(UAnimMontage* AnimMontage, float InPlayRate = 1, FName StartSectionName = NAME_None);
 	void M_PlayMontage_Implementation(UAnimMontage* AnimMontage, float InPlayRate = 1, FName StartSectionName = NAME_None);

--- a/Source/AbyssDiverUnderWorld/Monster/Serpmare/Serpmare.cpp
+++ b/Source/AbyssDiverUnderWorld/Monster/Serpmare/Serpmare.cpp
@@ -150,6 +150,11 @@ void ASerpmare::RemoveDetection(AActor* Actor)
 	// 기존에 MonsterState를 Patrol로 바꿔주었으나 Serpmare는 BT와 AM 상에서 모든 State를 전환함. 그래서 필요 없음
 }
 
+void ASerpmare::ReceiveKnockback(const FVector& Force)
+{
+	// 넉백 당하지 않음.
+}
+
 void ASerpmare::InitAttackInterval()
 {
 	bCanAttack = true;

--- a/Source/AbyssDiverUnderWorld/Monster/Serpmare/Serpmare.h
+++ b/Source/AbyssDiverUnderWorld/Monster/Serpmare/Serpmare.h
@@ -23,7 +23,6 @@ public:
 
 public:
 
-
 	virtual void Attack() override;
 
 	virtual void NotifyLightExposure(float DeltaTime, float TotalExposedTime, const FVector& PlayerLocation, AActor* PlayerActor) override;
@@ -31,6 +30,8 @@ public:
 	virtual void AddDetection(AActor* Actor) override;
 
 	virtual void RemoveDetection(AActor* Actor) override;
+
+	virtual void ReceiveKnockback(const FVector& Force) override;
 
 private:
 	void InitAttackInterval();

--- a/Source/AbyssDiverUnderWorld/Projectile/ADShotgunBullet.cpp
+++ b/Source/AbyssDiverUnderWorld/Projectile/ADShotgunBullet.cpp
@@ -39,39 +39,20 @@ void AADShotgunBullet::HandleHit(AActor* HitActor, const FHitResult& Hit)
 	//KnockDir.Z = 0.f;
 	KnockDir.Normalize();
 
-	bool bShouldKnockback = false;
-	// 현재는 하드코딩이지만 고정형 몬스터가 많아지면 확장성 있게 변경해야 할 듯함.(보스 몬스터)
-	if (Cast<ASerpmare>(HitActor)) 
+	if (AMonster* Monster = Cast<AMonster>(HitActor))
 	{
-		bShouldKnockback = false;
+		Monster->ReceiveKnockback(KnockDir * KnockbackStrength);
 	}
-	else if (Cast<ABoss>(HitActor) || Cast<AMonster>(HitActor))
+	/* 물리 시뮬레이션 중인 다른 액터라면 Impulse */
+	else if (UPrimitiveComponent* Prim = Cast<UPrimitiveComponent>(Hit.GetComponent()))
 	{
-		bShouldKnockback = true;
+		if (Prim->IsSimulatingPhysics())
+		{
+			Prim->AddImpulseAtLocation(KnockDir * KnockbackStrength, Hit.ImpactPoint);
+		}
 	}
 
-	if (bShouldKnockback)
-	{
-		if (ACharacter* Char = Cast<ACharacter>(HitActor))
-		{
-			/*Char->LaunchCharacter(KnockDir * KnockbackStrength, true, true);*/
-			// LaunchCharacter 대신 AddImpulse 사용
-			if (UCharacterMovementComponent* MovementComp = Char->GetCharacterMovement())
-			{
-				// 임펄스로 밀기 (자연스럽게 감소함)
-				MovementComp->AddImpulse(KnockDir * KnockbackStrength, true);
-			}
-		}
-		/* 물리 시뮬레이션 중인 다른 액터라면 Impulse */
-		else if (UPrimitiveComponent* Prim = Cast<UPrimitiveComponent>(Hit.GetComponent()))
-		{
-			if (Prim->IsSimulatingPhysics())
-			{
-				Prim->AddImpulseAtLocation(KnockDir * KnockbackStrength, Hit.ImpactPoint);
-			}
-		}
-	}
-	LOG(TEXT("Before Apply Damage : %d"), Damage);
+	LOGV(Log, TEXT("Before Apply Damage : %d"), Damage);
 
 	UGameplayStatics::ApplyPointDamage(
 		HitActor,
@@ -82,7 +63,7 @@ void AADShotgunBullet::HandleHit(AActor* HitActor, const FHitResult& Hit)
 		GetOwner(),
 		UDamageType::StaticClass());
 
-	LOG(TEXT("After Apply Damage : %d"), Damage);
+	LOGV(Log, TEXT("After Apply Damage : %d"), Damage);
 
 	Deactivate();   // 베이스 클래스 Deactivate() 호출로 풀에 반환
 }


### PR DESCRIPTION


---

# 📝 작업 상세 내용
## 🐛 bugfix EyeStalker
- 눈꺼풀 안 움직이는 현상 수정
- EyeStalker를 배치한 각도에 따라 응시 방향이 비정상적으로 변하는 현상 수정

## ✨ update EyeStalker 피격 모션, 몬스터 넉백 기능
- EyeStalker 피격 모션 : 데미지를 받으면 잠시 움츠러드는 효과 추가
- Monster 넉백 함수 추가

## 자세한 설명
- BP_EyeStalker : 피격시 움즈러드는 효과 추가
- BP_TentacleEye : 타겟 응시 방향 로직 수정
- SK_TentacleEye_Thick, SK_TentacleEye_Thin : 눈꺼풀 Morph Target 복원
- EyeStalker : 데미지를 받을 때 호출되는 블루프린트 전용 이벤트 추가, 샷건에 넉백 당하지 않도록 override
- Limadon, Serpmare : 샷건에 넉백 당하지 않도록 override
- Monster : 자기 자신을 해당 방향에 특정 힘으로 넉백 시키는 함수 추가
- ADShotgunBullet : Monster 넉백 함수를 대신 사용해서 넉백시킴
---
